### PR TITLE
Use strict utm parser

### DIFF
--- a/component.json
+++ b/component.json
@@ -15,7 +15,7 @@
     "segmentio/json": "1.0.0",
     "segmentio/protocol": "0.0.2",
     "segmentio/top-domain": "1.0.0",
-    "segmentio/utm-params": "1.0.2",
+    "segmentio/utm-params": "1.1.0",
     "yields/send-json": "1.1.1",
     "yields/store": "1.0.2"
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ Segment.prototype.normalize = function(msg) {
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
-  if (query) ctx.campaign = utm(query);
+  if (query) ctx.campaign = utm.strict(query);
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -204,6 +204,24 @@ describe('Segment.io', function() {
         Segment.global = window;
       });
 
+      it('should add only specced fields to .campaign', function() {
+        Segment.global = { navigator: {}, location: {} };
+        Segment.global.location.search = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_test=test&utm_fake=fake';
+        Segment.global.location.hostname = 'localhost';
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.context);
+        analytics.assert(object.context.campaign);
+        analytics.assert(object.context.campaign.source === 'source');
+        analytics.assert(object.context.campaign.medium === 'medium');
+        analytics.assert(object.context.campaign.term === 'term');
+        analytics.assert(object.context.campaign.content === 'content');
+        analytics.assert(object.context.campaign.name === 'name');
+        analytics.assert(object.context.campaign.test === undefined);
+        analytics.assert(object.context.campaign.fake === undefined);
+        Segment.global = window;
+      });
+
       it('should add .referrer.id and .referrer.type', function() {
         Segment.global = { navigator: {}, location: {} };
         Segment.global.location.search = '?utm_source=source&urid=medium';


### PR DESCRIPTION
We should only populate the 5 [spec'd context.campaign fields](https://segment.com/docs/spec/common/#structure) when we parse the querystring. This PR adopts our utm parser's new [strict mode](https://github.com/segmentio/utm-params/commit/964964647e86fe0f00bb8ba45fdab74c0d57f35e) to ensure that.

Our existing implementation will return an unbounded object with _any key_ prefixed `utm_`, causing, for example, unbounded column addition in redshift. This fix is especially important because customers are not in control of their own UTM params —any referrer can populate them erroneously and we see that happen often.

@ndhoule @reinpk 

cc/ @ivolo @wcjohnson11... you both were interested in seeing this fix through on slack :)
