### PR TITLE
Emit errors when the request fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,11 @@ Segment.prototype.send = function(path, msg, fn) {
   // send
   send(url, msg, headers, function(err, res) {
     self.debug('sent %O, received %O', msg, arguments);
-    if (err) return fn(err);
+    if (err) {
+      self.analytics.emit('error', err);
+      return fn(err);
+    }
+
     res.url = url;
     fn(null, res);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -405,6 +405,18 @@ describe('Segment.io', function() {
         });
       });
 
+      it('should emit an error when the request doesn\'t succeed', function(done) {
+        var emittedErr;
+        analytics.on('error', function(err) { emittedErr = err; });
+
+        protocol('http:');
+        segment.send('/u', { userId: 'id' }, function(err) {
+          assert(err);
+          assert.strictEqual(emittedErr, err);
+          done();
+        });
+      });
+
       describe('/g', ensure('/g', { groupId: 'gid', userId: 'uid' }));
       describe('/p', ensure('/p', { userId: 'id', name: 'page', properties: {} }));
       describe('/a', ensure('/a', { userId: 'id', from: 'b', to: 'a' }));


### PR DESCRIPTION
I believe @cristiandouce has been talking with your support team about the details of the issues we are experiencing, but we need a mechanism to detect when a request to segment (via analytics.js) fails. The callbacks that can be provided to methods like `track`, `page`, `identify` and so on, don't yield any information about the status of the request.

One solution we came up with is to emit errors when the request fails and it is implemented in this pull request. Unfortunately, in order for this to actually work, [yields/send-json](https://github.com/yields/send-json) needs to be updated. A [pull request](https://github.com/yields/send-json/pull/5) has already been sent. .
