### PR TITLE
increasing `messageId` randomness

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,6 +9,7 @@
     "component/clone": "0.1.0",
     "component/cookie": "1.1.1",
     "gjohnson/uuid": "0.0.1",
+    "satazor/SparkMD5": "1.0.0",
     "segmentio/ad-params": "0.0.2",
     "segmentio/analytics.js-integration": "^1.0.1",
     "segmentio/extend": "0.0.1",

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var extend = require('extend');
 var integration = require('analytics.js-integration');
 var json = require('segmentio/json@1.0.0');
 var localstorage = require('store');
+var md5 = require('SparkMD5').hash;
 var protocol = require('protocol');
 var send = require('send-json');
 var topDomain = require('top-domain');
@@ -168,8 +169,9 @@ Segment.prototype.normalize = function(msg) {
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
-  msg.messageId = uuid();
   msg.sentAt = new Date();
+  // add some randomness to the messageId checksum
+  msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
   this.debug('normalized %o', msg);
   return msg;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,6 +162,16 @@ describe('Segment.io', function() {
         analytics.assert(object.messageId.length === 36);
       });
 
+      it('should properly randomize .messageId', function() {
+        var set = {};
+        var count = 10000;
+        for (var i = 0; i < count; i++) {
+          var id = segment.normalize(object).messageId;
+          set[id] = true;
+        }
+        analytics.assert(Object.keys(set).length === count);
+      });
+
       it('should add .library', function() {
         segment.normalize(object);
         analytics.assert(object.context.library);


### PR DESCRIPTION
We've started seeing more and more of the same messageIds coming
through-and the main part of the problem is that Math.random()
isn't a strong source of randomness since it's purely derived
from the timestamp.

This commit makes sure that each individual message will have
stronger randomness (by hashing the message itself) as well as
adding a nonce for multiple messages sent by the same client
in the same ms.

New message ids follow the form:

  `"ajs-" + md5(json.stringify(msg) + uuid())`

We'll also start prefixing the library name so individual
messages are easy to track down and correlate.
