### PR TITLE
Swap out send-json for internal version

### DIFF
--- a/component.json
+++ b/component.json
@@ -17,7 +17,7 @@
     "segmentio/protocol": "0.0.2",
     "segmentio/top-domain": "1.0.0",
     "segmentio/utm-params": "1.0.2",
-    "yields/send-json": "1.1.1",
+    "segmentio/send-json": "2.0.0",
     "yields/store": "1.0.2"
   },
   "development": {


### PR DESCRIPTION
This changes out send-json to point to ours for workflow reasons. The important underlying change is that this version is urlsafe.

@calvinfo 
