### PR TITLE
add traits to context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,8 +161,10 @@ Segment.prototype.normalize = function(msg) {
   var global = exports.global;
   var query = global.location.search;
   var ctx = msg.context = msg.context || msg.options || {};
+  var traits = this.analytics.user().traits();
   delete msg.options;
   msg.writeKey = this.options.apiKey;
+  ctx.traits = ctx.traits || traits;
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
   if (query) ctx.campaign = utm(query);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -152,6 +152,30 @@ describe('Segment.io', function() {
         analytics.assert(object.options == null);
       });
 
+      it('should add traits to context', function() {
+        var traits = {
+          show: 'Bobs burger',
+          favoriteCharacter: 'Louise'
+        };
+        analytics.user().traits(traits);
+        segment.normalize(object);
+        analytics.assert(object.context.traits);
+        analytics.assert(object.context.traits.show === 'Bobs burger');
+        analytics.assert(object.context.traits.favoriteCharacter === 'Louise');
+      });
+
+      it('should not rewrite traits if provided', function() {
+        var object = { context: {
+          traits: {
+            race: 'zerg'
+          }
+        }};
+        analytics.user().traits({ race: 'protoss' });
+        segment.normalize(object);
+        analytics.assert(object.context);
+        analytics.assert(object.context.traits.race === 'zerg');
+      });
+
       it('should add .writeKey', function() {
         segment.normalize(object);
         analytics.assert(object.writeKey === segment.options.apiKey);


### PR DESCRIPTION
This will start adding `traits` to the context object for every call which is how the mobile libraries work.

We will respect the `context.traits` if it was provided with the call -- otherwise we will look up the cached traits via `analytics.user().traits()` and send that.

TODO: 
- [ ] update docs
- [x] comms redshift users

@f2prateek @segment-integrations/core 
