### PR TITLE
revert context-traits auto-sending

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,10 +162,8 @@ Segment.prototype.normalize = function(msg) {
   var global = exports.global;
   var query = global.location.search;
   var ctx = msg.context = msg.context || msg.options || {};
-  var traits = this.analytics.user().traits();
   delete msg.options;
   msg.writeKey = this.options.apiKey;
-  ctx.traits = ctx.traits || traits;
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
   if (query) ctx.campaign = utm(query);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,30 +162,6 @@ describe('Segment.io', function() {
         analytics.assert(object.options == null);
       });
 
-      it('should add traits to context', function() {
-        var traits = {
-          show: 'Bobs burger',
-          favoriteCharacter: 'Louise'
-        };
-        analytics.user().traits(traits);
-        segment.normalize(object);
-        analytics.assert(object.context.traits);
-        analytics.assert(object.context.traits.show === 'Bobs burger');
-        analytics.assert(object.context.traits.favoriteCharacter === 'Louise');
-      });
-
-      it('should not rewrite traits if provided', function() {
-        var object = { context: {
-          traits: {
-            race: 'zerg'
-          }
-        } };
-        analytics.user().traits({ race: 'protoss' });
-        segment.normalize(object);
-        analytics.assert(object.context);
-        analytics.assert(object.context.traits.race === 'zerg');
-      });
-
       it('should add .writeKey', function() {
         segment.normalize(object);
         analytics.assert(object.writeKey === segment.options.apiKey);


### PR DESCRIPTION
This has not been adopted by warehouses nor any SS ints yet, so we're reverting for the time being until we can make this optional (soon!). No customer impact.
