### PR TITLE
Allow configuration of API endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,7 +199,8 @@ Segment.prototype.ampId = function(ctx) {
  */
 
 Segment.prototype.send = function(path, msg, fn) {
-  var url = scheme() + '//api.segment.io/v1' + path;
+  var apiHost = this.options.apiHost || 'api.segment.io/v1';
+  var url = scheme() + '//' + apiHost + path;
   var headers = { 'Content-Type': 'text/plain' };
   fn = fn || noop;
   var self = this;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,9 +23,7 @@ var isPhantomJS = (/PhantomJS/).test(window.navigator.userAgent);
 describe('Segment.io', function() {
   var segment;
   var analytics;
-  var options = {
-    apiKey: 'oq0vdlg7yi'
-  };
+  var options;
 
   before(function() {
     // Just to make sure that `cookie()`
@@ -35,6 +33,7 @@ describe('Segment.io', function() {
   });
 
   beforeEach(function() {
+    options = { apiKey: 'oq0vdlg7yi' };
     protocol.reset();
     analytics = new Analytics();
     segment = new Segment(options);
@@ -455,6 +454,34 @@ describe('Segment.io', function() {
         assert(spy.calledOnce);
         var req = spy.getCall(0).args[0];
         assert.strictEqual(req.url, 'https://api.segment.io/v1/i');
+      }));
+
+      it('should send to `api.segment.io/v1` by default', sinon.test(function() {
+        var xhr = sinon.useFakeXMLHttpRequest();
+        var spy = sinon.spy();
+        xhr.onCreate = spy;
+
+        protocol('https:');
+        segment.send('/i', { userId: 'id' });
+
+        assert(spy.calledOnce);
+        var req = spy.getCall(0).args[0];
+        assert.strictEqual(req.url, 'https://api.segment.io/v1/i');
+      }));
+
+      it('should send to `options.apiHost` when set', sinon.test(function() {
+        segment.options.apiHost = 'api.example.com';
+
+        var xhr = sinon.useFakeXMLHttpRequest();
+        var spy = sinon.spy();
+        xhr.onCreate = spy;
+
+        protocol('https:');
+        segment.send('/i', { userId: 'id' });
+
+        assert(spy.calledOnce);
+        var req = spy.getCall(0).args[0];
+        assert.strictEqual(req.url, 'https://api.example.com/i');
       }));
 
       // FIXME(ndhoule): See note at `isPhantomJS` definition


### PR DESCRIPTION
This changeset allows you to change host the integration sends data to
by changing `options.apiHost`.
