### PR TITLE
Allow attaching additional metadata to every request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,6 +172,7 @@ Segment.prototype.normalize = function(msg) {
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
+  extend(msg, this._extras);
   // add some randomness to the messageId checksum
   msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
   this.debug('normalized %o', msg);
@@ -265,6 +266,10 @@ Segment.prototype.referrerId = function(query, ctx) {
   if (!ad) return;
   ctx.referrer = extend(ctx.referrer || {}, ad);
   this.cookie('s:context.referrer', json.stringify(ad));
+};
+
+Segment.prototype._attachMetadata = function(metadata) {
+  this._extras = extend(this._extras || {}, metadata);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,10 @@ Segment.prototype.normalize = function(msg) {
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
-  extend(msg, this._extras);
+  // Attach global metadata to each object if it was specified
+  if (this._metadata) {
+    msg.__metadata__ = this._metadata;
+  }
   // add some randomness to the messageId checksum
   msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
   this.debug('normalized %o', msg);
@@ -269,7 +272,7 @@ Segment.prototype.referrerId = function(query, ctx) {
 };
 
 Segment.prototype._attachMetadata = function(metadata) {
-  this._extras = extend(this._extras || {}, metadata);
+  this._metadata = extend(this._metadata || {}, metadata);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -284,7 +284,8 @@ describe('Segment.io', function() {
         segment._attachMetadata({ prop1: 'a' });
         segment.normalize(object);
         analytics.assert(object);
-        analytics.assert(object.prop1 === 'a');
+        analytics.assert(object.__metadata__);
+        analytics.assert(object.__metadata__.prop1 === 'a');
       });
 
       it('should add multiple attached metadata', function() {
@@ -292,8 +293,9 @@ describe('Segment.io', function() {
         segment._attachMetadata({ prop2: 'b' });
         segment.normalize(object);
         analytics.assert(object);
-        analytics.assert(object.prop1 === 'a');
-        analytics.assert(object.prop2 === 'b');
+        analytics.assert(object.__metadata__);
+        analytics.assert(object.__metadata__.prop1 === 'a');
+        analytics.assert(object.__metadata__.prop2 === 'b');
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -279,6 +279,22 @@ describe('Segment.io', function() {
         analytics.assert(object.context);
         analytics.assert(!object.context.amp);
       });
+
+      it('should add attached metadata', function() {
+        segment._attachMetadata({ prop1: 'a' });
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.prop1 === 'a');
+      });
+
+      it('should add multiple attached metadata', function() {
+        segment._attachMetadata({ prop1: 'a' });
+        segment._attachMetadata({ prop2: 'b' });
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.prop1 === 'a');
+        analytics.assert(object.prop2 === 'b');
+      });
     });
   });
 


### PR DESCRIPTION
INT-553

This will facilitate adding metadata to each request, such as which analytics.js integrations are enabled.
