### PR TITLE
Add bundled integrations metadata to every request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@
 var ads = require('@segment/ad-params');
 var clone = require('component-clone');
 var cookie = require('component-cookie');
-var each = require('@ndhoule/each');
 var extend = require('@ndhoule/extend');
+var foldl = require('@ndhoule/foldl');
 var integration = require('@segment/analytics.js-integration');
 var json = require('json3');
 var localstorage = require('yields-store');
@@ -175,10 +175,10 @@ Segment.prototype.normalize = function(msg) {
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
   if (this.options.addEnabledMetadata) {
-    var enabled = {};
-    each(function(_, name) {
+    var enabled = foldl(function(enabled, integration, name) {
       enabled[name] = true;
-    }, this.analytics.Integrations);
+      return enabled;
+    }, {}, this.analytics.Integrations);
     msg._metadata = {
       enabled: enabled
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ var cookieOptions = {
 var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
   .option('apiHost', 'api.segment.io/v1')
-  .option('addEnabledMetadata', false);
+  .option('addBundledMetadata', false);
 
 /**
  * Get the store.
@@ -174,13 +174,13 @@ Segment.prototype.normalize = function(msg) {
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
-  if (this.options.addEnabledMetadata) {
-    var enabled = foldl(function(enabled, integration, name) {
-      enabled[name] = true;
-      return enabled;
+  if (this.options.addBundledMetadata) {
+    var bundled = foldl(function(bundled, integration, name) {
+      bundled[name] = true;
+      return bundled;
     }, {}, this.analytics.Integrations);
     msg._metadata = {
-      enabled: enabled
+      bundled: bundled
     };
   }
   // add some randomness to the messageId checksum

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 var ads = require('@segment/ad-params');
 var clone = require('component-clone');
 var cookie = require('component-cookie');
+var each = require('@ndhoule/each');
 var extend = require('@ndhoule/extend');
 var integration = require('@segment/analytics.js-integration');
 var json = require('json3');
@@ -35,7 +36,8 @@ var cookieOptions = {
 
 var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
-  .option('apiHost', 'api.segment.io/v1');
+  .option('apiHost', 'api.segment.io/v1')
+  .option('addEnabledMetadata', false);
 
 /**
  * Get the store.
@@ -172,6 +174,15 @@ Segment.prototype.normalize = function(msg) {
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
+  if (this.options.addEnabledMetadata) {
+    var enabled = {};
+    each(function(_, name) {
+      enabled[name] = true;
+    }, this.analytics.Integrations);
+    msg._metadata = {
+      enabled: enabled
+    };
+  }
   // add some randomness to the messageId checksum
   msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
   this.debug('normalized %o', msg);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-segmentio#readme",
   "dependencies": {
+    "@ndhoule/each": "^2.0.1",
     "@ndhoule/extend": "^2.0.0",
     "@segment/ad-params": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
@@ -34,6 +35,7 @@
     "component-clone": "^0.2.2",
     "component-cookie": "^1.1.2",
     "component-type": "^1.2.1",
+    "each": "^0.6.1",
     "json3": "^3.3.2",
     "spark-md5": "^2.0.2",
     "uuid": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-segmentio#readme",
   "dependencies": {
-    "@ndhoule/each": "^2.0.1",
     "@ndhoule/extend": "^2.0.0",
+    "@ndhoule/foldl": "^2.0.1",
     "@segment/ad-params": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/protocol": "^1.0.0",
@@ -35,7 +35,6 @@
     "component-clone": "^0.2.2",
     "component-cookie": "^1.1.2",
     "component-type": "^1.2.1",
-    "each": "^0.6.1",
     "json3": "^3.3.2",
     "spark-md5": "^2.0.2",
     "uuid": "^2.0.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -285,11 +285,12 @@ describe('Segment.io', function() {
         var opts = extend({ addEnabledMetadata: true }, options);
         var Analytics = analytics.constructor;
         var ajs = new Analytics();
+        var segment = new Segment(opts);
         ajs.use(Segment);
         ajs.use(integration('other'));
-        ajs.initialize({ 'Segment.io': opts, other: {} });
+        ajs.add(segment);
+        ajs.initialize({ other: {} });
 
-        segment = ajs._integrations['Segment.io'];
         segment.normalize(object);
         assert(object);
         assert(object._metadata);
@@ -297,6 +298,20 @@ describe('Segment.io', function() {
           'Segment.io': true,
           other: true
         });
+      });
+
+      it('should not add a list of enabled integrations when `addEnabledMetadata` is unset', function() {
+        var Analytics = analytics.constructor;
+        var ajs = new Analytics();
+        var segment = new Segment(options);
+        ajs.use(Segment);
+        ajs.use(integration('other'));
+        ajs.add(segment);
+        ajs.initialize({ other: {} });
+
+        segment.normalize(object);
+        assert(object);
+        assert(!object._metadata);
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -518,6 +518,25 @@ describe('Segment.io', function() {
         assert.strictEqual(req.url, 'https://api.example.com/i');
       }));
 
+      it('should send a normalized payload', sinon.test(function() {
+        var xhr = sinon.useFakeXMLHttpRequest();
+        var spy = sinon.spy();
+        xhr.onCreate = spy;
+
+        var payload = {
+          key1: 'value1',
+          key2: 'value2'
+        };
+
+        segment.normalize = function() { return payload; };
+
+        segment.send('/i', {});
+
+        assert(spy.calledOnce);
+        var req = spy.getCall(0).args[0];
+        assert.strictEqual(req.requestBody, JSON.stringify(payload));
+      }));
+
       // FIXME(ndhoule): See note at `isPhantomJS` definition
       (isPhantomJS ? xdescribe : describe)('e2e tests', function() {
         describe('/g', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -281,8 +281,8 @@ describe('Segment.io', function() {
         analytics.assert(!object.context.amp);
       });
 
-      it('should add a list of enabled integrations when `addEnabledMetadata` is set', function() {
-        var opts = extend({ addEnabledMetadata: true }, options);
+      it('should add a list of bundled integrations when `addBundledMetadata` is set', function() {
+        var opts = extend({ addBundledMetadata: true }, options);
         var Analytics = analytics.constructor;
         var ajs = new Analytics();
         var segment = new Segment(opts);
@@ -294,13 +294,13 @@ describe('Segment.io', function() {
         segment.normalize(object);
         assert(object);
         assert(object._metadata);
-        assert.deepEqual(object._metadata.enabled, {
+        assert.deepEqual(object._metadata.bundled, {
           'Segment.io': true,
           other: true
         });
       });
 
-      it('should not add a list of enabled integrations when `addEnabledMetadata` is unset', function() {
+      it('should not add a list of bundled integrations when `addBundledMetadata` is unset', function() {
         var Analytics = analytics.constructor;
         var ajs = new Analytics();
         var segment = new Segment(options);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ var JSON = require('json3');
 var Segment = require('../lib/');
 var assert = require('proclaim');
 var cookie = require('component-cookie');
+var extend = require('@ndhoule/extend');
 var integration = require('@segment/analytics.js-integration');
 var protocol = require('@segment/protocol');
 var sandbox = require('@segment/clear-env');
@@ -278,6 +279,24 @@ describe('Segment.io', function() {
         analytics.assert(object);
         analytics.assert(object.context);
         analytics.assert(!object.context.amp);
+      });
+
+      it('should add a list of enabled integrations when `addEnabledMetadata` is set', function() {
+        var opts = extend({ addEnabledMetadata: true }, options);
+        var Analytics = analytics.constructor;
+        var ajs = new Analytics();
+        ajs.use(Segment);
+        ajs.use(integration('other'));
+        ajs.initialize({ 'Segment.io': opts, other: {} });
+
+        segment = ajs._integrations['Segment.io'];
+        segment.normalize(object);
+        assert(object);
+        assert(object._metadata);
+        assert.deepEqual(object._metadata.enabled, {
+          'Segment.io': true,
+          other: true
+        });
       });
     });
   });


### PR DESCRIPTION
INT-537

When the `addBundledMetadata` option is specified, adds metadata to every request under the `_metadata` key specifying which client-side integrations are enabled. Looks like:

```
{
  ...
  "_metadata": {
    "bundled": {
      "Segment.io": true,
      "Mixpanel": true
    }
  },
  ...
}
```
