### PR TITLE
Add unbundled metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,9 @@ var ads = require('@segment/ad-params');
 var clone = require('component-clone');
 var cookie = require('component-cookie');
 var extend = require('@ndhoule/extend');
-var foldl = require('@ndhoule/foldl');
 var integration = require('@segment/analytics.js-integration');
 var json = require('json3');
+var keys = require('@ndhoule/keys');
 var localstorage = require('yields-store');
 var md5 = require('spark-md5').hash;
 var protocol = require('@segment/protocol');
@@ -37,7 +37,8 @@ var cookieOptions = {
 var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
   .option('apiHost', 'api.segment.io/v1')
-  .option('addBundledMetadata', false);
+  .option('addBundledMetadata', false)
+  .option('unbundledIntegrations', []);
 
 /**
  * Get the store.
@@ -175,12 +176,10 @@ Segment.prototype.normalize = function(msg) {
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
   if (this.options.addBundledMetadata) {
-    var bundled = foldl(function(bundled, integration, name) {
-      bundled[name] = true;
-      return bundled;
-    }, {}, this.analytics.Integrations);
+    var bundled = keys(this.analytics.Integrations);
     msg._metadata = {
-      bundled: bundled
+      bundled: bundled,
+      unbundled: this.options.unbundledIntegrations
     };
   }
   // add some randomness to the messageId checksum

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-segmentio#readme",
   "dependencies": {
     "@ndhoule/extend": "^2.0.0",
-    "@ndhoule/foldl": "^2.0.1",
+    "@ndhoule/keys": "^2.0.0",
     "@segment/ad-params": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/protocol": "^1.0.0",


### PR DESCRIPTION
This allows the integration to take in a list of unbundled integrations and pass it through under `_metadata` when the `addBundledMetadata` option is specified. It also switches the `bundled` metadata to a list for consistency.
