### PR TITLE
Add beacon support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,13 @@
 
+3.2.2 / 2017-01-02
+==================
+
+  * Add beacon support (#19)
+
 3.2.1 / 2016-11-03
 ==================
 
-  * Always send requests over HTTPS 
+  * Always send requests over HTTPS
 
 3.2.0 / 2016-09-01
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ var cookieOptions = {
 var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
   .option('apiHost', 'api.segment.io/v1')
+  .option('beacon', false)
   .option('addBundledMetadata', false)
   .option('unbundledIntegrations', []);
 
@@ -211,7 +212,6 @@ Segment.prototype.ampId = function(ctx) {
 
 Segment.prototype.send = function(path, msg, fn) {
   var url = 'https://' + this.options.apiHost + path;
-  var headers = { 'Content-Type': 'text/plain' };
   fn = fn || noop;
   var self = this;
 
@@ -219,12 +219,30 @@ Segment.prototype.send = function(path, msg, fn) {
   msg = this.normalize(msg);
 
   // send
-  send(url, msg, headers, function(err, res) {
-    self.debug('sent %O, received %O', msg, arguments);
-    if (err) return fn(err);
-    res.url = url;
-    fn(null, res);
-  });
+  if (this.options.beacon && navigator.sendBeacon) {
+    // Beacon returns false if the browser couldn't queue the data for transfer
+    // (e.g: the data was too big)
+    if (navigator.sendBeacon(url, json.stringify(msg))) {
+      self.debug('beacon sent %o', msg);
+      fn();
+    } else {
+      self.debug('beacon failed, falling back to ajax %o', msg);
+      sendAjax();
+    }
+  } else {
+    sendAjax();
+  }
+
+  function sendAjax() {
+    // Beacons are sent as a text/plain POST
+    var headers = { 'Content-Type': 'text/plain' };
+    send(url, msg, headers, function(err, res) {
+      self.debug('ajax sent %o, received %o', msg, arguments);
+      if (err) return fn(err);
+      res.url = url;
+      fn(null, res);
+    });
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/protocol": "^1.0.0",
     "@segment/send-json": "^3.0.0",
-    "@segment/spy": "^1.0.1",
     "@segment/top-domain": "^3.0.0",
     "@segment/utm-params": "^2.0.0",
     "component-clone": "^0.2.2",


### PR DESCRIPTION
Adds support for the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API). The Beacon API allows you to send simple requests in the background which continue to be executed by the browser even during page loads, like after a link click or form submit (unlike AJAX requests which usually gets cancelled). 

This allows link clicks and form submits to be reliably tracked without degrading the user experience with ugly timeout hacks (making [analytics.trackLink()](https://segment.com/docs/sources/website/analytics.js/#track-link) and [analytics.trackForm()](https://segment.com/docs/sources/website/analytics.js/#track-form) unnecessary).

Depends on https://github.com/segmentio/app/pull/2882 and https://github.com/segmentio/cdn/pull/131

@jgershen @ndhoule @hankim813 