### PR TITLE
fix(normalize): Allow override context.campaign

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,10 @@ Segment.prototype.normalize = function(msg) {
       ctx.traits.crossDomainId = crossDomainId;
     }
   }
-  if (query) ctx.campaign = utm(query);
+  // if user provides campaign via context, do not overwrite with UTM qs param
+  if (query && !ctx.campaign) {
+    ctx.campaign = utm(query);
+  }
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -228,6 +228,33 @@ describe('Segment.io', function() {
         Segment.global = window;
       });
 
+      it('should allow override of .campaign', function() {
+        Segment.global = { navigator: {}, location: {} };
+        Segment.global.location.search = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name';
+        Segment.global.location.hostname = 'localhost';
+        var object = {
+          context: {
+            campaign: {
+              source: 'overrideSource',
+              medium: 'overrideMedium',
+              term: 'overrideTerm',
+              content: 'overrideContent',
+              name: 'overrideName'
+            }
+          }
+        };
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.context);
+        analytics.assert(object.context.campaign);
+        analytics.assert(object.context.campaign.source === 'overrideSource');
+        analytics.assert(object.context.campaign.medium === 'overrideMedium');
+        analytics.assert(object.context.campaign.term === 'overrideTerm');
+        analytics.assert(object.context.campaign.content === 'overrideContent');
+        analytics.assert(object.context.campaign.name === 'overrideName');
+        Segment.global = window;
+      });
+
       it('should add .referrer.id and .referrer.type', function() {
         Segment.global = { navigator: {}, location: {} };
         Segment.global.location.search = '?utm_source=source&urid=medium';
@@ -761,15 +788,15 @@ describe('Segment.io', function() {
       afterEach(function() {
         server.restore();
       });
-      
+
       it('should migrate cookies from old to new name', function() {
         segment.cookie('segment_cross_domain_id', 'xid-test-1');
         segment.initialize();
-        
+
         analytics.assert(segment.cookie('segment_cross_domain_id') == null);
         analytics.assert(segment.cookie('seg_xid') === 'xid-test-1');
       });
-      
+
       it('should not crash with invalid config', function() {
         segment.options.crossDomainIdServers = undefined;
 


### PR DESCRIPTION
- If an override context.campaign is provided, do not overwrite with UTM
  from querystring

closes https://github.com/segmentio/analytics.js-core/issues/34