### PR TITLE
Revert TLD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,14 +205,12 @@ Segment.prototype.normalize = function(msg) {
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
-  if (this.options.crossDomainIdServers) {
-    var crossDomainId = this.cookie('seg_xid');
-    if (crossDomainId) {
-      if (!ctx.traits) {
-        ctx.traits = { crossDomainId: crossDomainId };
-      } else if (ctx.traits && !ctx.traits.crossDomainId) {
-        ctx.traits.crossDomainId = crossDomainId;
-      }
+  var crossDomainId = this.cookie('seg_xid');
+  if (crossDomainId) {
+    if (!ctx.traits) {
+      ctx.traits = { crossDomainId: crossDomainId };
+    } else if (!ctx.traits.crossDomainId) {
+      ctx.traits.crossDomainId = crossDomainId;
     }
   }
   // if user provides campaign via context, do not overwrite with UTM qs param
@@ -359,7 +357,7 @@ Segment.prototype.referrerId = function(query, ctx) {
 Segment.prototype.retrieveCrossDomainId = function(callback) {
   if (!this.options.crossDomainIdServers) {
     if (callback) {
-      callback(new Error('crossDomainId not enabled'));
+      callback('crossDomainId not enabled', null);
     }
     return;
   }
@@ -380,7 +378,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
     getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {
       if (err) {
         // We optimize for no conflicting xid as much as possible. So bail out if there is an
-        // error and we cannot be sure that xid does not exist on any other domains.
+        // error and we cannot be sure that xid does not exist on any other domains
         if (callback) {
           callback(err, null);
         }
@@ -461,7 +459,7 @@ function getCrossDomainIdFromSingleServer(domain, writeKey, callback) {
   var endpoint = 'https://' + domain + '/v1/id/' + writeKey;
   getJson(endpoint, function(err, res) {
     if (err) {
-      callback(err);
+      callback(err, null);
     } else {
       callback(null, {
         domain: domain,

--- a/lib/index.js
+++ b/lib/index.js
@@ -365,7 +365,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
     var self = this;
     var writeKey = this.options.apiKey;
 
-    // Exclude the current domain from the list of servers we're querying.
+    // Exclude the current domain from the list of servers we're querying
     var currentTld = getTld(window.location.hostname);
     var domains = [];
     for (var i=0; i<this.options.crossDomainIdServers.length; i++) {
@@ -490,24 +490,14 @@ function getJson(url, callback) {
   xhr.send();
 }
 
+//
 /**
  * getTld
- *
  * Get domain.com from subdomain.domain.com, etc.
- *
- * Note that topDomain only works correctly if you currently on the domain
- * you're checking. This is ok for us, since if you are on segment.com
- * we want topDomain('xid.segment.com') to return segment.com
- * and don't care about topDomain('xid.nightmarejs.org') returning "".
- * topDomain('localhost') returns '' so we need an explicit check for it.
- *
  * @param {string} domain
  */
 function getTld(domain) {
-  if (domain === 'localhost') {
-    return 'localhost';
-  }
-  return topDomain(window.location.hostname);
+  return domain.split('.').splice(-2).join('.');
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -349,30 +349,6 @@ Segment.prototype.referrerId = function(query, ctx) {
   this.cookie('s:context.referrer', json.stringify(ad));
 };
 
-/**
- * _getCurrentHostname
- *
- * Returns window.location.hostname.
- */
-Segment.prototype._getCurrentHostname = function() {
-  return window.location.hostname;
-};
-
-/**
- * _getTld
- *
- * Get domain.com from subdomain.domain.com, etc.
- *
- * Note that topDomain only works correctly if you currently on the domain
- * you're checking. This is ok for us, since if you are on segment.com
- * we want topDomain('xid.segment.com') to return segment.com
- * and don't care about topDomain('xid.nightmarejs.org') returning "".
- *
- * @param {string} domain
- */
-Segment.prototype._getTld = function(domain) {
-  return topDomain(domain);
-};
 
 /**
  * retrieveCrossDomainId.
@@ -392,11 +368,11 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
     var writeKey = this.options.apiKey;
 
     // Exclude the current domain from the list of servers we're querying.
-    var currentTld = this._getTld(this._getCurrentHostname());
+    var currentTld = getTld(window.location.hostname);
     var domains = [];
-    for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
+    for (var i=0; i<this.options.crossDomainIdServers.length; i++) {
       var domain = this.options.crossDomainIdServers[i];
-      if (this._getTld(domain) !== currentTld) {
+      if (getTld(domain) !== currentTld) {
         domains.push(domain);
       }
     }
@@ -417,7 +393,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
         fromDomain = res.domain;
       } else {
         crossDomainId = uuid();
-        fromDomain = self._getCurrentHostname();
+        fromDomain = window.location.hostname;
       }
       var currentTimeMillis = (new Date()).getTime();
       self.cookie('seg_xid', crossDomainId);
@@ -515,6 +491,27 @@ function getJson(url, callback) {
   };
   xhr.send();
 }
+
+/**
+ * getTld
+ *
+ * Get domain.com from subdomain.domain.com, etc.
+ *
+ * Note that topDomain only works correctly if you currently on the domain
+ * you're checking. This is ok for us, since if you are on segment.com
+ * we want topDomain('xid.segment.com') to return segment.com
+ * and don't care about topDomain('xid.nightmarejs.org') returning "".
+ * topDomain('localhost') returns '' so we need an explicit check for it.
+ *
+ * @param {string} domain
+ */
+function getTld(domain) {
+  if (domain === 'localhost') {
+    return 'localhost';
+  }
+  return topDomain(window.location.hostname);
+}
+
 
 /**
  * Noop.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -808,7 +808,7 @@ describe('Segment.io', function() {
         });
 
         analytics.assert(!res);
-        analytics.assert(err.message === 'crossDomainId not enabled');
+        analytics.assert(err === 'crossDomainId not enabled');
       });
 
       it('should generate xid locally if there is only one (current hostname) server', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -780,19 +780,8 @@ describe('Segment.io', function() {
         segment.options.crossDomainIdServers = [
           'userdata.example1.com',
           'xid.domain2.com',
-          'xid.domain3.com'
+          'localhost'
         ];
-        segment._getCurrentHostname = function() {
-          return 'example1.com';
-        };
-        segment._getTld = function(domain) {
-          if (domain === 'example1.com' || domain === 'userdata.example1.com') {
-            return 'example1.com';
-          }
-          // Mimic topDomain which returns "" if you check a domain you're not
-          // currently on.
-          return '';
-        };
         analytics.stub(segment, 'onidentify');
       });
 
@@ -824,7 +813,7 @@ describe('Segment.io', function() {
 
       it('should generate xid locally if there is only one (current hostname) server', function() {
         segment.options.crossDomainIdServers = [
-          'userdata.example1.com'
+          'localhost'
         ];
 
         var res = null;
@@ -837,7 +826,7 @@ describe('Segment.io', function() {
         analytics.assert(crossDomainId);
 
         analytics.assert(res.crossDomainId === crossDomainId);
-        assert.strictEqual(res.fromDomain, 'example1.com');
+        analytics.assert(res.fromDomain === 'localhost');
       });
 
       it('should obtain crossDomainId', function() {
@@ -853,31 +842,11 @@ describe('Segment.io', function() {
         server.respond();
 
         var identify = segment.onidentify.args[0];
-        assert.strictEqual(identify[0].traits().crossDomainId, 'xdomain-id-1');
-        assert.strictEqual(res.crossDomainId, 'xdomain-id-1');
-        assert.strictEqual(res.fromDomain, 'xid.domain2.com');
+        analytics.assert(identify[0].traits().crossDomainId === 'xdomain-id-1');
+
+        analytics.assert(res.crossDomainId === 'xdomain-id-1');
+        analytics.assert(res.fromDomain === 'xid.domain2.com');
       });
-
-      it('should not make a request to the current domain', function() {
-        segment.retrieveCrossDomainId();
-        server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-          200,
-          { 'Content-Type': 'application/json' },
-          '{ "id": null }'
-        ]);
-        server.respondWith('GET', 'https://xid.domain3.com/v1/id/' + segment.options.apiKey, [
-          200,
-          { 'Content-Type': 'application/json' },
-          '{ "id": null }'
-        ]);
-        server.respondWith('GET', 'https://userid.example1.com/v1/id/', function() {
-          assert.fail();
-        });
-        server.respond();
-
-        assert.strictEqual(server.requests.length, 2); // Verify only 2 requests were made.
-      });
-
 
       it('should generate crossDomainId if no server has it', function() {
         var res = null;
@@ -890,7 +859,7 @@ describe('Segment.io', function() {
           { 'Content-Type': 'application/json' },
           '{ "id": null }'
         ]);
-        server.respondWith('GET', 'https://xid.domain3.com/v1/id/' + segment.options.apiKey, [
+        server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
           200,
           { 'Content-Type': 'application/json' },
           '{ "id": null }'
@@ -900,8 +869,9 @@ describe('Segment.io', function() {
         var identify = segment.onidentify.args[0];
         var crossDomainId = identify[0].traits().crossDomainId;
         analytics.assert(crossDomainId);
-        assert.strictEqual(res.crossDomainId, crossDomainId);
-        assert.strictEqual(res.fromDomain, 'example1.com');
+
+        analytics.assert(res.crossDomainId === crossDomainId);
+        analytics.assert(res.fromDomain === 'localhost');
       });
 
       it('should bail if all servers error', function() {
@@ -917,7 +887,7 @@ describe('Segment.io', function() {
           { 'Content-Type': 'application/json' },
           ''
         ]);
-        server.respondWith('GET', 'https://xid.domain3.com/v1/id/' + segment.options.apiKey, [
+        server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
           500,
           { 'Content-Type': 'application/json' },
           ''
@@ -943,7 +913,7 @@ describe('Segment.io', function() {
           { 'Content-Type': 'application/json' },
           ''
         ]);
-        server.respondWith('GET', 'https://xid.domain3.com/v1/id/' + segment.options.apiKey, [
+        server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
           200,
           { 'Content-Type': 'application/json' },
           '{ "id": null }'
@@ -969,7 +939,7 @@ describe('Segment.io', function() {
           { 'Content-Type': 'application/json' },
           ''
         ]);
-        server.respondWith('GET', 'https://xid.domain3.com/v1/id/' + segment.options.apiKey, [
+        server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
           200,
           { 'Content-Type': 'application/json' },
           '{ "id": "xidxid" }'
@@ -978,8 +948,9 @@ describe('Segment.io', function() {
 
         var identify = segment.onidentify.args[0];
         analytics.assert(identify[0].traits().crossDomainId === 'xidxid');
-        assert.strictEqual(res.crossDomainId, 'xidxid');
-        assert.strictEqual(res.fromDomain, 'xid.domain3.com');
+
+        analytics.assert(res.crossDomainId === 'xidxid');
+        analytics.assert(res.fromDomain === 'userdata.example1.com');
         analytics.assert(!err);
       });
     });


### PR DESCRIPTION
This reverts commits https://github.com/segment-integrations/analytics.js-integration-segmentio/commit/042807ad00e6b3a6a3b65cb150a30bd85b8c9597, https://github.com/segment-integrations/analytics.js-integration-segmentio/commit/85d45f5d6d86c3a7f793f0566e7e8bbe3b8a4931 and https://github.com/segment-integrations/analytics.js-integration-segmentio/commit/66ef6c175094a1abb504f2dca2444d143e337b5d which were introduced after 3.4.0.

It looks like these introduced a regression that caused the "self" domain check to have the opposite behaviour we want. time.com was making a request to only `xid.time.com` and none of the other domains (which is the opposite of what we want). This is already mitigated in production.

https://github.com/segment-integrations/analytics.js-integration-segmentio/commit/4bf0e3c226055ec642e27e8c69bc994d800fea93 and https://github.com/segment-integrations/analytics.js-integration-segmentio/commit/231b1d739d07cb7a9a9193242228c28d5a5ea056 are left as is.