### PR TITLE
cap message queue to 100 items

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,6 @@ var queueOptions = {
   maxRetryDelay: 360000, // max interval of 1hr
   minRetryDelay: 1000, // first attempt (1s)
   backoffFactor: 2,
-  backoffJitter: 1,
   maxAttempts: 45,
   maxItems: 100
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -241,7 +241,6 @@ Segment.prototype.normalize = function(msg) {
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
-  msg.timestamp = new Date();
   msg.sentAt = new Date();
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,24 @@ var cookieOptions = {
 };
 
 /**
+ * Queue options
+ *
+ * for first hour, attempt with backoff
+ *    Sum[k^2, {k, 0, 21}] = 3311000 (55min)
+ * for remaining 23 hours, attempt 1/hr (linear)
+ * total = 45 attempts
+ */
+
+var queueOptions = {
+  maxRetryDelay: 360000, // max interval of 1hr
+  minRetryDelay: 1000, // first attempt (1s)
+  backoffFactor: 2,
+  backoffJitter: 1,
+  maxAttempts: 45,
+  maxItems: 100
+};
+
+/**
  * Expose `Segment` integration.
  */
 
@@ -71,9 +89,9 @@ Segment.prototype.initialize = function() {
   var self = this;
 
   if (this.options.retryQueue) {
-    this._lsqueue = new Queue('segmentio', function(item, done) {
+    this._lsqueue = new Queue('segmentio', queueOptions, function(item, done) {
       // apply sentAt at flush time and reset on each retry
-      // so the tracking-api doesn't interperet a time skew
+      // so the tracking-api doesn't interpret a time skew
       item.msg.sentAt = new Date();
       // send
       send(item.url, item.msg, item.headers, function(err, res) {
@@ -223,6 +241,7 @@ Segment.prototype.normalize = function(msg) {
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
+  msg.timestamp = new Date();
   msg.sentAt = new Date();
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ndhoule/keys": "^2.0.0",
     "@segment/ad-params": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
-    "@segment/localstorage-retry": "^1.1.0",
+    "@segment/localstorage-retry": "^1.2.0",
     "@segment/protocol": "^1.0.0",
     "@segment/send-json": "^3.0.0",
     "@segment/top-domain": "^3.0.0",


### PR DESCRIPTION
Team:

This is the final proposed update before releasing beginning to roll out queueing to our broader customer base. It addresses the only issue encountered by our largest beta partner (who is monitoring its behavior in production across millions of browsers): when the device is offline for a very long time, the queue can grow large and use a lot of memory. There are valid usage patterns for that customer's users where this can become an issue. The other way this same issue can rear its head is in the exceedingly rare case when analytics.js itself is not blocked but the API is (causing infinite retries and unbounded queue growth).

The associated upstream PR is here: https://github.com/segmentio/localstorage-retry/pull/8

I followed the recommendations in our new `analytics-foo` doc, with the exception of setting max retries over the suggestion of 10. Given the nature of the platform, I'm more comfortable front loading a **bunch** of retries with ^2 exp backoff (+/- jitter) for the first hour and then moving to once an hour for the remainder of a day. The logic for how I arrived at the backoff settings that accomplish this is inline in the comment.

Reasoning for 100 max items: localstorage is a shared resource capped at 5 or 10mb depending on the browser. With per-event max @ 32kb, 100 max items is 3.2M. Most events aren't that large, but that's about as large as I'm comfortable growing. Anything higher than that also seems inappropriate for the case when we swap to in-memory due to a quota exceeded error. This means that in certain cases when the device is offline for a long time, we could drop events, but I'm comfortable with those parameters (and they match what we do in our mobile SDKs and server libraries where the max queue size is upheld irrespective of whether the flush has succeeded). 

Finally, the biggest change to be attentive to in this case is that I have added client-side timestamp marking. Given the API is already adept at timestamp skew correction across all platforms with client-set timestamps (eg. mobile and server), I'm comfortable with this change. The reason I think this is an improvement is the *event time* (rather than reception/processing time) will be reflected in downstream tools that support it. We are overwriting `sentAt` on each attempted flush, which the API will use for skew detection. 

Looking forward to your thoughts! 



