### PR TITLE
support strict utm parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ var Segment = exports = module.exports = integration('Segment.io')
   .option('crossDomainIdServers', [])
   .option('retryQueue', false)
   .option('addBundledMetadata', false)
+  .option('strictUTM', false)
   .option('unbundledIntegrations', []);
 
 /**
@@ -216,6 +217,10 @@ Segment.prototype.normalize = function(msg) {
       ctx.traits.crossDomainId = crossDomainId;
     }
   }
+
+  // only use strict parsing on new / deliberately enabled
+  utm = this.options.strictUTM ? utm.strict : utm;
+
   // if user provides campaign via context, do not overwrite with UTM qs param
   if (query && !ctx.campaign) {
     ctx.campaign = utm(query);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,7 +214,7 @@ describe('Segment.io', function() {
 
       it('should add .campaign', function() {
         Segment.global = { navigator: {}, location: {} };
-        Segment.global.location.search = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name';
+        Segment.global.location.search = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_test=val';
         Segment.global.location.hostname = 'localhost';
         segment.normalize(object);
         analytics.assert(object);
@@ -225,6 +225,7 @@ describe('Segment.io', function() {
         analytics.assert(object.context.campaign.term === 'term');
         analytics.assert(object.context.campaign.content === 'content');
         analytics.assert(object.context.campaign.name === 'name');
+        analytics.assert(object.context.campaign.test === 'val');
         Segment.global = window;
       });
 
@@ -252,6 +253,25 @@ describe('Segment.io', function() {
         analytics.assert(object.context.campaign.term === 'overrideTerm');
         analytics.assert(object.context.campaign.content === 'overrideContent');
         analytics.assert(object.context.campaign.name === 'overrideName');
+        Segment.global = window;
+      });
+
+      it('should add only specced fields to .campaign if strictmode is enabled', function() {
+        segment.options.strictUTM = true;
+        Segment.global = { navigator: {}, location: {} };
+        Segment.global.location.search = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_test=test&utm_fake=fake';
+        Segment.global.location.hostname = 'localhost';
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.context);
+        analytics.assert(object.context.campaign);
+        analytics.assert(object.context.campaign.source === 'source');
+        analytics.assert(object.context.campaign.medium === 'medium');
+        analytics.assert(object.context.campaign.term === 'term');
+        analytics.assert(object.context.campaign.content === 'content');
+        analytics.assert(object.context.campaign.name === 'name');
+        analytics.assert(object.context.campaign.test === undefined);
+        analytics.assert(object.context.campaign.fake === undefined);
         Segment.global = window;
       });
 


### PR DESCRIPTION
Allows us to move the new default to strict parsing and show an option for users to enable it on existing projects without breaking the "feature" (bug) of supporting other utm types. proposed rollout / sequencing plan [here](https://paper.dropbox.com/doc/strict-utm-sequencing-EZo2yMtKjBszl9xuRUWr3)