### PR TITLE
Pass failed initializations as  metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,7 @@ exports.global = window;
 
 Segment.prototype.initialize = function() {
   var self = this;
-
+  
   if (this.options.retryQueue) {
     this._lsqueue = new Queue('segmentio', queueOptions, function(item, done) {
       // apply sentAt at flush time and reset on each retry
@@ -241,12 +241,16 @@ Segment.prototype.normalize = function(msg) {
   msg.userId = msg.userId || user.id();
   msg.anonymousId = user.anonymousId();
   msg.sentAt = new Date();
+  // Add _metadata.
+  var failedInitializations = this.analytics.failedInitializations || [];
+  if (failedInitializations.length > 0) {
+    msg._metadata = { failedInitializations: failedInitializations };
+  }
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);
-    msg._metadata = {
-      bundled: bundled,
-      unbundled: this.options.unbundledIntegrations
-    };
+    msg._metadata = msg._metadata || {};
+    msg._metadata.bundled = bundled;
+    msg._metadata.unbundled = this.options.unbundledIntegrations;
   }
   // add some randomness to the messageId checksum
   msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yields-store": "^1.0.2"
   },
   "devDependencies": {
-    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-core": "^3.1.1",
     "@segment/analytics.js-integration-tester": "^2.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yields-store": "^1.0.2"
   },
   "devDependencies": {
-    "@segment/analytics.js-core": "^3.1.2",
+    "@segment/analytics.js-core": "^3.1.3",
     "@segment/analytics.js-integration-tester": "^2.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yields-store": "^1.0.2"
   },
   "devDependencies": {
-    "@segment/analytics.js-core": "^3.1.1",
+    "@segment/analytics.js-core": "^3.1.2",
     "@segment/analytics.js-integration-tester": "^2.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -312,6 +312,21 @@ describe('Segment.io', function() {
         analytics.assert(!object.context.amp);
       });
 
+      describe('failed initializations', function() {
+        it('should add failedInitializations as part of _metadata object if this.analytics.failedInitilizations is not empty', function() {
+          var spy = sinon.spy(segment, 'normalize');
+          var TestIntegration = integration('TestIntegration');
+          TestIntegration.prototype.initialize = function() { throw new Error('Uh oh!'); };
+          TestIntegration.prototype.page = function() {};
+          var testIntegration = new TestIntegration();
+          analytics.use(TestIntegration);
+          analytics.add(testIntegration);
+          analytics.initialize();
+          analytics.page();
+          assert(spy.returnValues[0]._metadata.failedInitializations[0] === 'TestIntegration');
+        });
+      }); 
+
       describe('unbundling', function() {
         var segment;
 


### PR DESCRIPTION
PR updates the `normalize`  method to check for any `failedInitializations` and passes that list as part of the `_metadata` payload.