### PR TITLE
Be less aggressive with retries.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,17 +34,16 @@ var cookieOptions = {
 /**
  * Queue options
  *
- * for first hour, attempt with backoff
- *    Sum[k^2, {k, 0, 21}] = 3311000 (55min)
- * for remaining 23 hours, attempt 1/hr (linear)
- * total = 45 attempts
+ * Attempt with exponential backoff for upto 10 times.
+ * Backoff periods are: 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s (~2m), 256s (~4m),
+ * 512s (~8.5m) and 1024s (~17m).
  */
 
 var queueOptions = {
-  maxRetryDelay: 360000, // max interval of 1hr
+  maxRetryDelay: 360000, // max interval of 1hr. Added as a guard.
   minRetryDelay: 1000, // first attempt (1s)
   backoffFactor: 2,
-  maxAttempts: 45,
+  maxAttempts: 10,
   maxItems: 100
 };
 
@@ -86,7 +85,7 @@ exports.global = window;
 
 Segment.prototype.initialize = function() {
   var self = this;
-  
+
   if (this.options.retryQueue) {
     this._lsqueue = new Queue('segmentio', queueOptions, function(item, done) {
       // apply sentAt at flush time and reset on each retry


### PR DESCRIPTION
Before this change, we retry each individual message upto 45 times in case of an error. Since we don't distinguish between error types and retry all errors, In certain cases (particularly when the requests fail due to  adblockers), this retry behaviour is overly aggressive and not desirable.

By reducing the number of retries, we can ensure that we still retry in the average case (i.e. flaky connections) but give up after a reasonable number of events. The downside is that in some cases, legitimate issues that cause us to burn through 10 attempts will not be retried. We're making the tradeoff of having better performance at the cost of slightly worse deliverability.

As a follow up to this, we should also mark certain errors as non-retryable (as per https://paper.dropbox.com/doc/Analytics-library-guidelines-2trBhLKQD4Soz4VatvuGR#:uid=189560039280582553736180&h2=Handling-Network-Errors) so we give up early for errors that are destined to fail, but still have a more aggressive retry policy for intermittent errors.