### PR TITLE
update send-json with timeout support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,8 +91,8 @@ Segment.prototype.initialize = function() {
       // apply sentAt at flush time and reset on each retry
       // so the tracking-api doesn't interpret a time skew
       item.msg.sentAt = new Date();
-      // send
-      send(item.url, item.msg, item.headers, function(err, res) {
+      // send with 10s timeout
+      send(item.url, item.msg, item.headers, 10 * 1000, function(err, res) {
         self.debug('sent %O, received %O', item.msg, [err, res]);
         if (err) return done(err);
         done(null, res);
@@ -292,7 +292,8 @@ Segment.prototype.enqueue = function(path, msg, fn) {
       msg: msg
     });
   } else {
-    send(url, msg, headers, function(err, res) {
+    // no timeout in the non-retry code path to preserve legacy behaviour.
+    send(url, msg, headers, null, function(err, res) {
       self.debug('sent %O, received %O', msg, [err, res]);
       if (fn) {
         if (err) return fn(err);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/localstorage-retry": "^1.2.0",
     "@segment/protocol": "^1.0.0",
-    "@segment/send-json": "^3.0.0",
+    "@segment/send-json": "^4.0.1",
     "@segment/top-domain": "^3.0.0",
     "@segment/utm-params": "^2.0.0",
     "component-clone": "^0.2.2",


### PR DESCRIPTION
Bump the send-json dependency to v4 so we can use the new timeout functionality. Currently we only set a timeout on the retry path to preserve legacy behaviour, though it would be a good idea to set a value here in the future as well.


Another improvement for the future would be to be able to set per project timeout values so customers can pick and choose. For now, we're using a default of 10 seconds to minimize changes to this code path.


Note - we need the changes from v4.0.1 (https://github.com/segmentio/send-json/blob/master/HISTORY.md#401--2018-04-16).