### PR TITLE
Set timeout on XHR requests when using retry functionality.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+/* eslint-disable no-restricted-globals */
 'use strict';
 
 module.exports = function(config) {
@@ -8,6 +9,41 @@ module.exports = function(config) {
     ],
 
     browsers: ['PhantomJS'],
+
+    middleware: ['server'],
+
+    plugins: [
+      'karma-*',
+      {
+        'middleware:server': [
+          'factory',
+          function() {
+            return function(request, response, next) {
+              if (request.url === '/base/data' && request.method === 'POST') {
+                var body = '';
+
+                request.on('data', function(data) {
+                  body += data;
+                });
+
+                request.on('end', function() {
+                  try {
+                    var data = JSON.parse(body);
+                    response.writeHead(data.length === 3 ? 200 : 400);
+                    return response.end(String(data.length === 3));
+                  } catch (err) {
+                    response.writeHead(500);
+                    return response.end();
+                  }
+                });
+              } else {
+                next();
+              }
+            };
+          }
+        ]
+      }
+    ],
 
     frameworks: ['browserify', 'mocha'],
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,6 +75,51 @@ exports.storage = function() {
 
 exports.global = window;
 
+
+/**
+ * Send the given `obj` and `headers` to `url` with the specified `timeout` and
+ * `fn(err, req)`. Exported for testing.
+ *
+ * @param {String} url
+ * @param {Object} obj
+ * @param {Object} headers
+ * @param {long} timeout
+ * @param {Function} fn
+ * @api private
+ */
+
+exports.sendJsonWithTimeout = function(url, obj, headers, timeout, fn) {
+  // only proceed with our new code path when cors is supported. this is
+  // unlikely to happen in production, but we're being safe to preserve backward
+  // compatibility.
+  if (send.type !== 'xhr') {
+    send(url, obj, headers, fn);
+    return;
+  }
+
+  var req = new XMLHttpRequest();
+  req.onerror = fn;
+  req.onreadystatechange = done;
+
+  req.open('POST', url, true);
+
+  req.timeout = timeout;
+  req.ontimeout = fn;
+
+  // TODO: Remove this eslint disable
+  // eslint-disable-next-line guard-for-in
+  for (var k in headers) {
+    req.setRequestHeader(k, headers[k]);
+  }
+  req.send(json.stringify(obj));
+
+  function done() {
+    if (req.readyState === 4) {
+      return fn(null, req);
+    }
+  }
+};
+
 /**
  * Initialize.
  *
@@ -91,8 +136,9 @@ Segment.prototype.initialize = function() {
       // apply sentAt at flush time and reset on each retry
       // so the tracking-api doesn't interpret a time skew
       item.msg.sentAt = new Date();
-      // send
-      send(item.url, item.msg, item.headers, function(err, res) {
+
+      // send with 10s timeout
+      Segment.sendJsonWithTimeout(item.url, item.msg, item.headers, 10 * 1000, function(err, res) {
         self.debug('sent %O, received %O', item.msg, [err, res]);
         if (err) return done(err);
         done(null, res);


### PR DESCRIPTION
It's a good idea to set a timeout for HTTP requests. Setting a timeout will help avoid resource contention when the network is flaky.

Originally I was going to make this change in send-json, but this requires an update to three repos, this one, segmentio/send-json#2, #41 and segmentio/analytics.js-private#227. And although the functionality is behind gated code, it could still be risky.

Since send-json v3 doesn't support timeouts and it isn't easy to add it without breaking backward compatibility, instead in this PR, I've copied the code and tests from send-json and added timeout support. This also makes it easier to run the new code under two very specific conditions, 1) the customer has opted into the retry queue functionality and 2) the browser supports CORS.

I think this approach will make it safer to rollout this change, and also easier to rollback in case something goes wrong.

The tests for this change were also conflicting with existing tests. Daniel pointed out that  we were using a fake XMLHttpRequest from sinon, but not cleaning up after tests. As part of this change I updated the existing tests to clean up after themselves.