### PR TITLE
Warn and ignore messages that are > 32kb.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,12 @@ var cookieOptions = {
   path: '/'
 };
 
+
+/**
+ * Segment messages can be a maximum of 32kb.
+ */
+var MAX_SIZE = 32 * 1000;
+
 /**
  * Queue options
  *
@@ -328,7 +334,14 @@ Segment.prototype.enqueue = function(path, msg, fn) {
   var url = 'https://' + this.options.apiHost + path;
   var headers = { 'Content-Type': 'text/plain' };
   msg = this.normalize(msg);
-  this.debug('enqueueing');
+
+  // Print a log statement when messages exceed the maximum size. In the future,
+  // we may consider dropping this event on the client entirely.
+  if (json.stringify(msg).length > MAX_SIZE) {
+    this.debug('message must be less than 32kb %O', msg);
+  }
+
+  this.debug('enqueueing %O', msg);
 
   var self = this;
   if (this.options.retryQueue) {


### PR DESCRIPTION
Our internal API will reject messages > 32kb. Since this happens in our internal API, this error never gets surfaced to clients. This adds a debug log when a user tries to send a message > 32kb.

In the future, we may choose to drop this message from the client entirely.

Ref: https://segment.atlassian.net/browse/LIB-253