### PR TITLE
Enable retryQueue by default.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
   .option('apiHost', 'api.segment.io/v1')
   .option('crossDomainIdServers', [])
-  .option('retryQueue', false)
+  .option('retryQueue', true)
   .option('addBundledMetadata', false)
   .option('unbundledIntegrations', []);
 


### PR DESCRIPTION
Now that we've graduated the feature out of beta, we should enable this by default for all customers.

Existing customers will have this flag set to false (LIB-608), so that they don't notice a change in behaviour after this lands.

