### PR TITLE
Fix testing logic

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -395,9 +395,10 @@ describe('Segment.io', function() {
     };
 
     for (var scenario in cases) {
-      if (cases.hasOwnProperty(scenario)) {
+      if (!cases.hasOwnProperty(scenario)) {
         continue;
       }
+
       describe('with ' + scenario, function() {
         beforeEach(function() {
           segment.options.retryQueue = cases[scenario];


### PR DESCRIPTION
In a previous change (https://github.com/segment-integrations/analytics.js-integration-segmentio/pull/49), I added table driven tests to ensure our tests pass when retryQueue enabled or disabled. However it unintentionally disabled these tests. Fixing the logic enables them again.