### PR TITLE
Use server timestamp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,16 +169,6 @@ Segment.prototype.initialize = function() {
     self.ready();
   });
 
-  // Migrate from old cross domain id cookie names
-  if (this.cookie('segment_cross_domain_id')) {
-    this.cookie('seg_xid', this.cookie('segment_cross_domain_id'));
-    this.cookie('seg_xid_fd', this.cookie('segment_cross_domain_id_from_domain'));
-    this.cookie('seg_xid_ts', this.cookie('segment_cross_domain_id_timestamp'));
-    this.cookie('segment_cross_domain_id', null);
-    this.cookie('segment_cross_domain_id_from_domain', null);
-    this.cookie('segment_cross_domain_id_timestamp', null);
-  }
-
   // At this moment we intentionally do not want events to be queued while we retrieve the `crossDomainId`
   // so `.ready` will get called right away and we'll try to figure out `crossDomainId`
   // separately
@@ -455,18 +445,20 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
       }
       var crossDomainId = null;
       var fromDomain = null;
+      var currentTimeMillis = (new Date()).getTime();
+      var timestamp = null;
       if (res) {
         crossDomainId = res.id;
         fromDomain = res.domain;
+        timestamp = res.timestamp || currentTimeMillis;
       } else {
         crossDomainId = uuid();
         fromDomain = window.location.hostname;
+        timestamp = currentTimeMillis;
       }
-      var currentTimeMillis = (new Date()).getTime();
       self.cookie('seg_xid', crossDomainId);
-      // Not actively used. Saving for future conflict resolution purposes
       self.cookie('seg_xid_fd', fromDomain);
-      self.cookie('seg_xid_ts', currentTimeMillis);
+      self.cookie('seg_xid_ts', timestamp);
       self.analytics.identify({
         crossDomainId: crossDomainId
       });
@@ -474,7 +466,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
         callback(null, {
           crossDomainId: crossDomainId,
           fromDomain: fromDomain,
-          timestamp: currentTimeMillis
+          timestamp: timestamp
         });
       }
     });
@@ -532,7 +524,8 @@ function getCrossDomainIdFromSingleServer(domain, writeKey, callback) {
     } else {
       callback(null, {
         domain: domain,
-        id: res && res.id || null
+        id: res && res.id || null,
+        timestamp: res && res.timestamp || null
       });
     }
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -839,14 +839,6 @@ describe('Segment.io', function() {
             server.restore();
           });
 
-          it('should migrate cookies from old to new name', function() {
-            segment.cookie('segment_cross_domain_id', 'xid-test-1');
-            segment.initialize();
-
-            analytics.assert(segment.cookie('segment_cross_domain_id') == null);
-            analytics.assert(segment.cookie('seg_xid') === 'xid-test-1');
-          });
-
           it('should not crash with invalid config', function() {
             segment.options.crossDomainIdServers = undefined;
 
@@ -887,7 +879,7 @@ describe('Segment.io', function() {
             server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
               200,
               { 'Content-Type': 'application/json' },
-              '{ "id": "xdomain-id-1" }'
+              '{ "id": "xdomain-id-1", "timestamp": 1540432000000 }'
             ]);
             server.respond();
 
@@ -896,6 +888,7 @@ describe('Segment.io', function() {
 
             analytics.assert(res.crossDomainId === 'xdomain-id-1');
             analytics.assert(res.fromDomain === 'xid.domain2.com');
+            analytics.assert.equal(res.timestamp, 1540432000000);
           });
 
           it('should generate crossDomainId if no server has it', function() {
@@ -922,6 +915,7 @@ describe('Segment.io', function() {
 
             analytics.assert(res.crossDomainId === crossDomainId);
             analytics.assert(res.fromDomain === 'localhost');
+            analytics.assert.notEqual(res.timestamp, null);
           });
 
           it('should bail if all servers error', function() {


### PR DESCRIPTION
Now that the XID server reflects the xid timestamp, we should use it when available instead of generating one locally.

This also removes the legacy cookies so that we don't have to update references anymore.