### PR TITLE
Don't send xid when cross domain analytics is disabled.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,7 @@ Segment.prototype.initialize = function() {
   // At this moment we intentionally do not want events to be queued while we retrieve the `crossDomainId`
   // so `.ready` will get called right away and we'll try to figure out `crossDomainId`
   // separately
-  if (this.options.crossDomainIdServers && this.options.crossDomainIdServers.length > 0) {
+  if (this.isCrossDomainAnalyticsEnabled()) {
     this.retrieveCrossDomainId();
   }
 };
@@ -282,7 +282,7 @@ Segment.prototype.normalize = function(msg) {
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
   var crossDomainId = this.cookie('seg_xid');
-  if (crossDomainId) {
+  if (crossDomainId && this.isCrossDomainAnalyticsEnabled()) {
     if (!ctx.traits) {
       ctx.traits = { crossDomainId: crossDomainId };
     } else if (!ctx.traits.crossDomainId) {
@@ -416,6 +416,20 @@ Segment.prototype.referrerId = function(query, ctx) {
   this.cookie('s:context.referrer', json.stringify(ad));
 };
 
+/**
+ * isCrossDomainAnalyticsEnabled returns true if cross domain analytics is enabled.
+ * This field is not directly supplied, so it is inferred by inspecting the
+ * `crossDomainIdServers` array in settings. If this array is null or empty,
+ * it is assumed that cross domain analytics is disabled.
+ *
+ * @api private
+ */
+Segment.prototype.isCrossDomainAnalyticsEnabled = function() {
+  if (!this.options.crossDomainIdServers) {
+    return false;
+  }
+  return this.options.crossDomainIdServers.length > 0;
+};
 
 /**
  * retrieveCrossDomainId.
@@ -424,7 +438,7 @@ Segment.prototype.referrerId = function(query, ctx) {
  * @param {function) callback => err, {crossDomainId, fromServer, timestamp}
  */
 Segment.prototype.retrieveCrossDomainId = function(callback) {
-  if (!this.options.crossDomainIdServers) {
+  if (!this.isCrossDomainAnalyticsEnabled()) {
     if (callback) {
       callback('crossDomainId not enabled', null);
     }


### PR DESCRIPTION
This adds an additional check in the normalize function to only attach the XID to events if cross domain analytics is enabled. The logic to determine if cross domain analytics is enabled is copied from an existing check - it is assumed to be disabled if no `crossDomainIdServers` were provided. This is also refactored into a shared function so we can avoid duplicating this logic.

Additionally this is written in a way that new check `isCrossDomainAnalyticsEnabled()` is only consulted if a xid cookie exists. This should prevent it from having unintended consequences on customers who have never used cross domain analytics.

Previously this check was skipped, and the xid would be sent as long as it exists in the cookie. To see this in action, you can go to any Segment source (without cross domain analytics enabled), create a cookie named `seg_xid`, and see that subsequent events from that site will send `context.traits.crossDomainId` in the event.



This code path was missing tests, so I added tests as well (there wasn't any test that needed to be updated).