### PR TITLE
Add flag and logic to delete cross domain identifiers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ var Segment = exports = module.exports = integration('Segment.io')
   .option('apiKey', '')
   .option('apiHost', 'api.segment.io/v1')
   .option('crossDomainIdServers', [])
+  .option('deleteCrossDomainId', false)
   .option('retryQueue', true)
   .option('addBundledMetadata', false)
   .option('unbundledIntegrations', []);
@@ -178,6 +179,9 @@ Segment.prototype.initialize = function() {
     this.cookie('segment_cross_domain_id_from_domain', null);
     this.cookie('segment_cross_domain_id_timestamp', null);
   }
+
+  // Delete cross domain identifiers.
+  this.deleteCrossDomainId();
 
   // At this moment we intentionally do not want events to be queued while we retrieve the `crossDomainId`
   // so `.ready` will get called right away and we'll try to figure out `crossDomainId`
@@ -493,6 +497,40 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
       }
     });
   }
+};
+
+/**
+ * deleteCrossDomainId deletes any state persisted by cross domain analytics.
+ * * seg_xid (and metadata) from cookies
+ * * crossDomainId from traits in localStorage
+ *
+ * The deletion logic is run only if deletion is enabled for this project, and
+ * when either the seg_xid cookie or crossDomainId localStorage trait exists.
+ *
+ * @api private
+ */
+Segment.prototype.deleteCrossDomainId = function() {
+  // Only continue if deletion is enabled for this project.
+  if (!this.options.deleteCrossDomainId) {
+    return;
+  }
+
+  // Only continue if we have any lingering identifiers.
+  if (this.cookie('seg_xid') == null && this.analytics.user().traits().crossDomainId == null) {
+    return;
+  }
+
+  // Delete xid cookies.
+  this.cookie('seg_xid', null);
+  this.cookie('seg_xid_fd', null);
+  this.cookie('seg_xid_ts', null);
+
+  // Delete localStorage traits. This intentionally uses an internal API, so that
+  // we can avoid interacting with lower level localStorage APIs, and instead
+  // leverage existing functionality inside analytics.js.
+  var traits = this.analytics.user().traits();
+  delete traits.crossDomainId;
+  this.analytics.user()._setTraits(traits);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@ Segment.prototype.initialize = function() {
   }
 
   // Delete cross domain identifiers.
-  this.deleteCrossDomainId();
+  this.deleteCrossDomainIdIfNeeded();
 
   // At this moment we intentionally do not want events to be queued while we retrieve the `crossDomainId`
   // so `.ready` will get called right away and we'll try to figure out `crossDomainId`
@@ -500,7 +500,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
 };
 
 /**
- * deleteCrossDomainId deletes any state persisted by cross domain analytics.
+ * Deletes any state persisted by cross domain analytics.
  * * seg_xid (and metadata) from cookies
  * * crossDomainId from traits in localStorage
  *
@@ -509,7 +509,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
  *
  * @api private
  */
-Segment.prototype.deleteCrossDomainId = function() {
+Segment.prototype.deleteCrossDomainIdIfNeeded = function() {
   // Only continue if deletion is enabled for this project.
   if (!this.options.deleteCrossDomainId) {
     return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -515,22 +515,23 @@ Segment.prototype.deleteCrossDomainIdIfNeeded = function() {
     return;
   }
 
-  // Only continue if we have any lingering identifiers.
-  if (this.cookie('seg_xid') == null && this.analytics.user().traits().crossDomainId == null) {
-    return;
+  // Delete the xid cookie if it exists. We also delete associated metadata.
+  if (this.cookie('seg_xid')) {
+    this.cookie('seg_xid', null);
+    this.cookie('seg_xid_fd', null);
+    this.cookie('seg_xid_ts', null);
   }
 
-  // Delete xid cookies.
-  this.cookie('seg_xid', null);
-  this.cookie('seg_xid_fd', null);
-  this.cookie('seg_xid_ts', null);
+  // Delete the crossDomainId trait in localStorage if it exists.
+  if (this.analytics.user().traits().crossDomainId) {
+    // This intentionally uses an internal API, so that
+    // we can avoid interacting with lower level localStorage APIs, and instead
+    // leverage existing functionality inside analytics.js.
 
-  // Delete localStorage traits. This intentionally uses an internal API, so that
-  // we can avoid interacting with lower level localStorage APIs, and instead
-  // leverage existing functionality inside analytics.js.
-  var traits = this.analytics.user().traits();
-  delete traits.crossDomainId;
-  this.analytics.user()._setTraits(traits);
+    var traits = this.analytics.user().traits();
+    delete traits.crossDomainId;
+    this.analytics.user()._setTraits(traits);
+  }
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1087,6 +1087,65 @@ describe('Segment.io', function() {
               assert.equal(segment.isCrossDomainAnalyticsEnabled(), true);
             });
           });
+
+          describe('deleteCrossDomainId', function() {
+            it('should not delete cross domain identifiers by default', function() {
+              segment.cookie('seg_xid', 'test_xid');
+              analytics.identify({
+                crossDomainId: 'test_xid'
+              });
+
+              segment.deleteCrossDomainId();
+
+              assert.equal(segment.cookie('seg_xid'), 'test_xid');
+              assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
+            });
+
+            it('should do not delete cross domain identifiers if disabled', function() {
+              segment.options.deleteCrossDomainId = false;
+
+              segment.cookie('seg_xid', 'test_xid');
+              analytics.identify({
+                crossDomainId: 'test_xid'
+              });
+
+              segment.deleteCrossDomainId();
+
+              assert.equal(segment.cookie('seg_xid'), 'test_xid');
+              assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
+            });
+
+            it('should delete cross domain identifiers if enabled', function() {
+              segment.options.deleteCrossDomainId = true;
+
+              segment.cookie('seg_xid', 'test_xid');
+              analytics.identify({
+                crossDomainId: 'test_xid'
+              });
+
+              segment.deleteCrossDomainId();
+
+              assert.equal(segment.cookie('seg_xid'), null);
+              assert.equal(analytics.user().traits().crossDomainId, null);
+            });
+
+            it('should not delete any other traits if enabled', function() {
+              segment.options.deleteCrossDomainId = true;
+
+              analytics.identify({
+                crossDomainId: 'test_xid',
+                name: 'Prateek',
+                age: 26
+              });
+
+              segment.deleteCrossDomainId();
+
+              assert.deepEqual(analytics.user().traits(), {
+                name: 'Prateek',
+                age: 26
+              });
+            });
+          });
         });
       });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1095,7 +1095,7 @@ describe('Segment.io', function() {
                 crossDomainId: 'test_xid'
               });
 
-              segment.deleteCrossDomainId();
+              segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), 'test_xid');
               assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
@@ -1109,7 +1109,7 @@ describe('Segment.io', function() {
                 crossDomainId: 'test_xid'
               });
 
-              segment.deleteCrossDomainId();
+              segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), 'test_xid');
               assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
@@ -1123,7 +1123,7 @@ describe('Segment.io', function() {
                 crossDomainId: 'test_xid'
               });
 
-              segment.deleteCrossDomainId();
+              segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), null);
               assert.equal(analytics.user().traits().crossDomainId, null);
@@ -1138,7 +1138,7 @@ describe('Segment.io', function() {
                 age: 26
               });
 
-              segment.deleteCrossDomainId();
+              segment.deleteCrossDomainIdIfNeeded();
 
               assert.deepEqual(analytics.user().traits(), {
                 name: 'Prateek',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1091,6 +1091,8 @@ describe('Segment.io', function() {
           describe('deleteCrossDomainId', function() {
             it('should not delete cross domain identifiers by default', function() {
               segment.cookie('seg_xid', 'test_xid');
+              segment.cookie('seg_xid_ts', 'test_xid_ts');
+              segment.cookie('seg_xid_fd', 'test_xid_fd');
               analytics.identify({
                 crossDomainId: 'test_xid'
               });
@@ -1098,6 +1100,8 @@ describe('Segment.io', function() {
               segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), 'test_xid');
+              assert.equal(segment.cookie('seg_xid_ts'), 'test_xid_ts');
+              assert.equal(segment.cookie('seg_xid_fd'), 'test_xid_fd');
               assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
             });
 
@@ -1105,6 +1109,8 @@ describe('Segment.io', function() {
               segment.options.deleteCrossDomainId = false;
 
               segment.cookie('seg_xid', 'test_xid');
+              segment.cookie('seg_xid_ts', 'test_xid_ts');
+              segment.cookie('seg_xid_fd', 'test_xid_fd');
               analytics.identify({
                 crossDomainId: 'test_xid'
               });
@@ -1112,6 +1118,8 @@ describe('Segment.io', function() {
               segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), 'test_xid');
+              assert.equal(segment.cookie('seg_xid_ts'), 'test_xid_ts');
+              assert.equal(segment.cookie('seg_xid_fd'), 'test_xid_fd');
               assert.equal(analytics.user().traits().crossDomainId, 'test_xid');
             });
 
@@ -1119,6 +1127,8 @@ describe('Segment.io', function() {
               segment.options.deleteCrossDomainId = true;
 
               segment.cookie('seg_xid', 'test_xid');
+              segment.cookie('seg_xid_ts', 'test_xid_ts');
+              segment.cookie('seg_xid_fd', 'test_xid_fd');
               analytics.identify({
                 crossDomainId: 'test_xid'
               });
@@ -1126,7 +1136,33 @@ describe('Segment.io', function() {
               segment.deleteCrossDomainIdIfNeeded();
 
               assert.equal(segment.cookie('seg_xid'), null);
+              assert.equal(segment.cookie('seg_xid_ts'), null);
+              assert.equal(segment.cookie('seg_xid_fd'), null);
               assert.equal(analytics.user().traits().crossDomainId, null);
+            });
+
+            it('should delete localStorage trait even if only traits exists', function() {
+              segment.options.deleteCrossDomainId = true;
+
+              analytics.identify({
+                crossDomainId: 'test_xid'
+              });
+
+              segment.deleteCrossDomainIdIfNeeded();
+
+              assert.equal(analytics.user().traits().crossDomainId, null);
+            });
+
+            it('should delete xid cookie even if only cookie exists', function() {
+              segment.options.deleteCrossDomainId = true;
+
+              segment.cookie('seg_xid', 'test_xid');
+
+              segment.deleteCrossDomainIdIfNeeded();
+
+              assert.equal(segment.cookie('seg_xid'), null);
+              assert.equal(segment.cookie('seg_xid_ts'), null);
+              assert.equal(segment.cookie('seg_xid_fd'), null);
             });
 
             it('should not delete any other traits if enabled', function() {


### PR DESCRIPTION
Some customers may want us to delete cross domain analytics related identifiers when it is disabled. This PR adds a new flag `deleteCrossDomainId` that is checked before running this new logic.

We delete  seg_xid (and metadata) from cookies and  crossDomainId from traits in localStorage. The deletion logic is run only if deletion is enabled for this project, and when either the seg_xid cookie or crossDomainId localStorage trait exists.

To delete the localStorage traits, we use an internal API in analytics.js. This minimizes the risk of introducing a bug that could arise due to interacting with lower level localStorage APIs directly.

Ref: https://segment.atlassian.net/browse/LIB-752