### PR TITLE
 save cross domain identifier cookies from the server as an option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ var Segment = exports = module.exports = integration('Segment.io')
   .option('apiHost', 'api.segment.io/v1')
   .option('crossDomainIdServers', [])
   .option('deleteCrossDomainId', false)
+  .option('saveCrossDomainIdInLocalStorage', false)
   .option('retryQueue', true)
   .option('addBundledMetadata', false)
   .option('unbundledIntegrations', []);
@@ -274,7 +275,7 @@ Segment.prototype.normalize = function(msg) {
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
   if (!ctx.library) ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
-  var crossDomainId = this.cookie('seg_xid');
+  var crossDomainId = this.getCachedCrossDomainId();
   if (crossDomainId && this.isCrossDomainAnalyticsEnabled()) {
     if (!ctx.traits) {
       ctx.traits = { crossDomainId: crossDomainId };
@@ -430,69 +431,132 @@ Segment.prototype.isCrossDomainAnalyticsEnabled = function() {
  */
 Segment.prototype.retrieveCrossDomainId = function(callback) {
   if (!this.isCrossDomainAnalyticsEnabled()) {
+    // Callback is only provided in tests.
     if (callback) {
       callback('crossDomainId not enabled', null);
     }
     return;
   }
-  if (!this.cookie('seg_xid')) {
-    var self = this;
-    var writeKey = this.options.apiKey;
 
-    // Exclude the current domain from the list of servers we're querying
-    var currentTld = getTld(window.location.hostname);
-    var domains = [];
-    for (var i=0; i<this.options.crossDomainIdServers.length; i++) {
-      var domain = this.options.crossDomainIdServers[i];
-      if (getTld(domain) !== currentTld) {
-        domains.push(domain);
+  var cachedCrossDomainId = this.getCachedCrossDomainId();
+  if (cachedCrossDomainId) {
+    // Callback is only provided in tests.
+    if (callback) {
+      callback(null, {
+        crossDomainId: cachedCrossDomainId
+      });
+    }
+    return;
+  }
+
+  var self = this;
+  var writeKey = this.options.apiKey;
+
+  // Exclude the current domain from the list of servers we're querying
+  var currentTld = getTld(window.location.hostname);
+  var domains = [];
+  for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
+    var domain = this.options.crossDomainIdServers[i];
+    if (getTld(domain) !== currentTld) {
+      domains.push(domain);
+    }
+  }
+
+  getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {
+    if (err) {
+      // Callback is only provided in tests.
+      if (callback) {
+        callback(err, null);
       }
+      // We optimize for no conflicting xid as much as possible. So bail out if there is an
+      // error and we cannot be sure that xid does not exist on any other domains.
+      return;
     }
 
-    getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {
-      if (err) {
-        // We optimize for no conflicting xid as much as possible. So bail out if there is an
-        // error and we cannot be sure that xid does not exist on any other domains
-        if (callback) {
-          callback(err, null);
-        }
-        return;
-      }
-      var crossDomainId = null;
-      var fromDomain = null;
-      if (res) {
-        crossDomainId = res.id;
-        fromDomain = res.domain;
-      } else {
-        crossDomainId = uuid();
-        fromDomain = window.location.hostname;
-      }
-      var currentTimeMillis = (new Date()).getTime();
-      self.cookie('seg_xid', crossDomainId);
-      // Not actively used. Saving for future conflict resolution purposes
-      self.cookie('seg_xid_fd', fromDomain);
-      self.cookie('seg_xid_ts', currentTimeMillis);
-      self.analytics.identify({
-        crossDomainId: crossDomainId
-      });
-      if (callback) {
-        callback(null, {
-          crossDomainId: crossDomainId,
-          fromDomain: fromDomain,
-          timestamp: currentTimeMillis
-        });
-      }
+    var crossDomainId = null;
+    var fromDomain = null;
+    if (res) {
+      crossDomainId = res.id;
+      fromDomain = res.domain;
+    } else {
+      crossDomainId = uuid();
+      fromDomain = window.location.hostname;
+    }
+
+    self.saveCrossDomainId(crossDomainId);
+    self.analytics.identify({
+      crossDomainId: crossDomainId
     });
+
+    // Callback is only provided in tests.
+    if (callback) {
+      callback(null, {
+        crossDomainId: crossDomainId,
+        fromDomain: fromDomain
+      });
+    }
+  });
+};
+
+/**
+ * getCachedCrossDomainId returns the cross domain identifier stored on the client based on the `saveCrossDomainIdInLocalStorage` flag.
+ * If `saveCrossDomainIdInLocalStorage` is false, it reads it from the `seg_xid` cookie.
+ * If `saveCrossDomainIdInLocalStorage` is true, it reads it from the `seg_xid` key in localStorage.
+ * 
+ * @return {string} crossDomainId
+ */
+Segment.prototype.getCachedCrossDomainId = function() {
+  if (this.options.saveCrossDomainIdInLocalStorage) {
+    return localstorage('seg_xid');
+  }
+  return this.cookie('seg_xid');
+};
+
+/**
+ * saveCrossDomainId saves the cross domain identifier. The implementation differs based on the `saveCrossDomainIdInLocalStorage` flag.
+ * If `saveCrossDomainIdInLocalStorage` is false, it saves it as the `seg_xid` cookie.
+ * If `saveCrossDomainIdInLocalStorage` is true, it saves it to localStorage (so that it can be accessed on the current domain)
+ * and as a httpOnly cookie (so that can it can be provided to other domains).
+ *
+ * @api private
+ */
+Segment.prototype.saveCrossDomainId = function(crossDomainId) {
+  if (!this.options.saveCrossDomainIdInLocalStorage) {
+    this.cookie('seg_xid', crossDomainId);
+    return;
+  }
+
+  var self = this;
+
+  // Save the cookie by making a request to the xid server for the current domain.
+  var currentTld = getTld(window.location.hostname);
+  for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
+    var domain = this.options.crossDomainIdServers[i];
+    if (getTld(domain) === currentTld) {
+      var writeKey = this.options.apiKey;
+      var url = 'https://' + domain + '/v1/saveId?writeKey=' + writeKey + '&xid=' + crossDomainId;
+
+      httpGet(url, function(err, res) {
+        if (err) {
+          self.debug('could not save id on %O, received %O', url, [err, res]);
+          return;
+        }
+
+        localstorage('seg_xid', crossDomainId);
+      });
+      return;
+    }
   }
 };
 
 /**
  * Deletes any state persisted by cross domain analytics.
  * * seg_xid (and metadata) from cookies
+ * * seg_xid from localStorage
  * * crossDomainId from traits in localStorage
  *
- * The deletion logic is run only if deletion is enabled for this project, and
- * when either the seg_xid cookie or crossDomainId localStorage trait exists.
+ * The deletion logic is run only if deletion is enabled for this project, and only
+ * deletes the data that actually exists.
  *
  * @api private
  */
@@ -507,6 +571,11 @@ Segment.prototype.deleteCrossDomainIdIfNeeded = function() {
     this.cookie('seg_xid', null);
     this.cookie('seg_xid_fd', null);
     this.cookie('seg_xid_ts', null);
+  }
+
+  // Delete the xid from localStorage if it exists.
+  if (localstorage('seg_xid')) {
+    localstorage('seg_xid', null);
   }
 
   // Delete the crossDomainId trait in localStorage if it exists.
@@ -593,6 +662,27 @@ function getJson(url, callback) {
         callback(null, xhr.responseText ? json.parse(xhr.responseText) : null);
       } else {
         callback(xhr.statusText || 'Unknown Error', null);
+      }
+    }
+  };
+  xhr.send();
+}
+
+/**
+ * get makes a get request to the given URL.
+ * @param {string} url
+ * @param {function} callback => err, response
+ */
+function httpGet(url, callback) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', url, true);
+  xhr.withCredentials = true;
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState === XMLHttpRequest.DONE) {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        callback(null, xhr.responseText);
+      } else {
+        callback(xhr.statusText || xhr.responseText || 'Unknown Error', null);
       }
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,16 +169,6 @@ Segment.prototype.initialize = function() {
     self.ready();
   });
 
-  // Migrate from old cross domain id cookie names
-  if (this.cookie('segment_cross_domain_id')) {
-    this.cookie('seg_xid', this.cookie('segment_cross_domain_id'));
-    this.cookie('seg_xid_fd', this.cookie('segment_cross_domain_id_from_domain'));
-    this.cookie('seg_xid_ts', this.cookie('segment_cross_domain_id_timestamp'));
-    this.cookie('segment_cross_domain_id', null);
-    this.cookie('segment_cross_domain_id_from_domain', null);
-    this.cookie('segment_cross_domain_id_timestamp', null);
-  }
-
   // Delete cross domain identifiers.
   this.deleteCrossDomainIdIfNeeded();
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -883,14 +883,6 @@ describe('Segment.io', function() {
             server.restore();
           });
 
-          it('should migrate cookies from old to new name', function() {
-            segment.cookie('segment_cross_domain_id', 'xid-test-1');
-            segment.initialize();
-
-            analytics.assert(segment.cookie('segment_cross_domain_id') == null);
-            analytics.assert(segment.cookie('seg_xid') === 'xid-test-1');
-          });
-
           it('should not crash with invalid config', function() {
             segment.options.crossDomainIdServers = undefined;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,12 +44,18 @@ describe('Segment.io', function() {
     analytics.add(segment);
     analytics.assert(Segment.global === window);
     resetCookies();
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
   });
 
   afterEach(function() {
     analytics.restore();
     analytics.reset();
     resetCookies();
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
     segment.reset();
     sandbox();
   });
@@ -897,148 +903,236 @@ describe('Segment.io', function() {
             analytics.assert(err === 'crossDomainId not enabled');
           });
 
-          it('should generate xid locally if there is only one (current hostname) server', function() {
+          it('should use cached cross domain identifier from LS when saveCrossDomainIdInLocalStorage is true', function() {
             segment.options.crossDomainIdServers = [
               'localhost'
             ];
+            segment.options.saveCrossDomainIdInLocalStorage = true;
+
+            store('seg_xid', 'test_xid_cache_ls');
 
             var res = null;
-            segment.retrieveCrossDomainId(function(err, response) {
-              res = response;
-            });
-
-            var identify = segment.onidentify.args[0];
-            var crossDomainId = identify[0].traits().crossDomainId;
-            analytics.assert(crossDomainId);
-
-            analytics.assert(res.crossDomainId === crossDomainId);
-            analytics.assert(res.fromDomain === 'localhost');
-          });
-
-          it('should obtain crossDomainId', function() {
-            var res = null;
-            segment.retrieveCrossDomainId(function(err, response) {
-              res = response;
-            });
-            server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-              200,
-              { 'Content-Type': 'application/json' },
-              '{ "id": "xdomain-id-1" }'
-            ]);
-            server.respond();
-
-            var identify = segment.onidentify.args[0];
-            analytics.assert(identify[0].traits().crossDomainId === 'xdomain-id-1');
-
-            analytics.assert(res.crossDomainId === 'xdomain-id-1');
-            analytics.assert(res.fromDomain === 'xid.domain2.com');
-          });
-
-          it('should generate crossDomainId if no server has it', function() {
-            var res = null;
-            segment.retrieveCrossDomainId(function(err, response) {
-              res = response;
-            });
-
-            server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-              200,
-              { 'Content-Type': 'application/json' },
-              '{ "id": null }'
-            ]);
-            server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
-              200,
-              { 'Content-Type': 'application/json' },
-              '{ "id": null }'
-            ]);
-            server.respond();
-
-            var identify = segment.onidentify.args[0];
-            var crossDomainId = identify[0].traits().crossDomainId;
-            analytics.assert(crossDomainId);
-
-            analytics.assert(res.crossDomainId === crossDomainId);
-            analytics.assert(res.fromDomain === 'localhost');
-          });
-
-          it('should bail if all servers error', function() {
             var err = null;
-            var res = null;
             segment.retrieveCrossDomainId(function(error, response) {
-              err = error;
               res = response;
+              err = error;
             });
 
-            server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-              500,
-              { 'Content-Type': 'application/json' },
-              ''
-            ]);
-            server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
-              500,
-              { 'Content-Type': 'application/json' },
-              ''
-            ]);
-            server.respond();
-
-            var identify = segment.onidentify.args[0];
-            analytics.assert(!identify);
-            analytics.assert(!res);
-            analytics.assert(err === 'Internal Server Error');
+            assert.isNull(err);
+            assert.deepEqual(res, {
+              crossDomainId: 'test_xid_cache_ls'
+            });
           });
 
-          it('should bail if some servers fail and others have no xid', function() {
+          it('should use cached cross domain identifier from cookies when saveCrossDomainIdInLocalStorage is false', function() {
+            segment.options.crossDomainIdServers = [
+              'localhost'
+            ];
+            segment.options.saveCrossDomainIdInLocalStorage = false;
+
+            segment.cookie('seg_xid', 'test_xid_cache_cookie');
+
+            var res = null;
             var err = null;
-            var res = null;
             segment.retrieveCrossDomainId(function(error, response) {
-              err = error;
               res = response;
+              err = error;
             });
 
-            server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-              400,
-              { 'Content-Type': 'application/json' },
-              ''
-            ]);
-            server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
-              200,
-              { 'Content-Type': 'application/json' },
-              '{ "id": null }'
-            ]);
-            server.respond();
-
-            var identify = segment.onidentify.args[0];
-            analytics.assert(!identify);
-            analytics.assert(!res);
-            analytics.assert(err === 'Bad Request');
+            assert.isNull(err);
+            assert.deepEqual(res, {
+              crossDomainId: 'test_xid_cache_cookie'
+            });
           });
 
-          it('should succeed even if one server fails', function() {
-            var err = null;
-            var res = null;
-            segment.retrieveCrossDomainId(function(error, response) {
-              err = error;
-              res = response;
+          describe('getCachedCrossDomainId', function() {
+            it('should return identifiers from localstorage when saveCrossDomainIdInLocalStorage is true', function() {
+              store('seg_xid', 'test_xid_cache_ls');
+              segment.cookie('seg_xid', 'test_xid_cache_cookie');
+
+              segment.options.saveCrossDomainIdInLocalStorage = true;
+
+              assert.equal(segment.getCachedCrossDomainId(), 'test_xid_cache_ls');
             });
 
-            server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
-              500,
-              { 'Content-Type': 'application/json' },
-              ''
-            ]);
-            server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
-              200,
-              { 'Content-Type': 'application/json' },
-              '{ "id": "xidxid" }'
-            ]);
-            server.respond();
+            it('should return identifiers from localstorage when saveCrossDomainIdInLocalStorage is true', function() {
+              store('seg_xid', 'test_xid_cache_ls');
+              segment.cookie('seg_xid', 'test_xid_cache_cookie');
 
-            var identify = segment.onidentify.args[0];
-            analytics.assert(identify[0].traits().crossDomainId === 'xidxid');
+              segment.options.saveCrossDomainIdInLocalStorage = false;
 
-            analytics.assert(res.crossDomainId === 'xidxid');
-            analytics.assert(res.fromDomain === 'userdata.example1.com');
-            analytics.assert(!err);
+              assert.equal(segment.getCachedCrossDomainId(), 'test_xid_cache_cookie');
+            });
           });
+
+          var cases = {
+            'saveCrossDomainIdInLocalStorage true': true,
+            'saveCrossDomainIdInLocalStorage false': false
+          };
+
+          for (var scenario in cases) {
+            if (!cases.hasOwnProperty(scenario)) {
+              continue;
+            }
+
+            describe('with ' + scenario, function() {
+              it('should generate xid locally if there is only one (current hostname) server', function() {
+                segment.options.crossDomainIdServers = [
+                  'localhost'
+                ];
+                segment.options.saveCrossDomainIdInLocalStorage = cases[scenario];
+
+                var res = null;
+                segment.retrieveCrossDomainId(function(err, response) {
+                  res = response;
+                });
+
+                var identify = segment.onidentify.args[0];
+                var crossDomainId = identify[0].traits().crossDomainId;
+                analytics.assert(crossDomainId);
+
+                analytics.assert(res.crossDomainId === crossDomainId);
+                analytics.assert(res.fromDomain === 'localhost');
+
+                assert.equal(segment.getCachedCrossDomainId(), crossDomainId);
+              });
+
+              it('should obtain crossDomainId', function() {
+                var res = null;
+                segment.retrieveCrossDomainId(function(err, response) {
+                  res = response;
+                });
+                server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
+                  200,
+                  { 'Content-Type': 'application/json' },
+                  '{ "id": "xdomain-id-1" }'
+                ]);
+                server.respond();
+
+                var identify = segment.onidentify.args[0];
+                analytics.assert(identify[0].traits().crossDomainId === 'xdomain-id-1');
+
+                analytics.assert(res.crossDomainId === 'xdomain-id-1');
+                analytics.assert(res.fromDomain === 'xid.domain2.com');
+
+                assert.equal(segment.getCachedCrossDomainId(), 'xdomain-id-1');
+              });
+
+              it('should generate crossDomainId if no server has it', function() {
+                var res = null;
+                segment.retrieveCrossDomainId(function(err, response) {
+                  res = response;
+                });
+
+                server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
+                  200,
+                  { 'Content-Type': 'application/json' },
+                  '{ "id": null }'
+                ]);
+                server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
+                  200,
+                  { 'Content-Type': 'application/json' },
+                  '{ "id": null }'
+                ]);
+                server.respond();
+
+                var identify = segment.onidentify.args[0];
+                var crossDomainId = identify[0].traits().crossDomainId;
+                analytics.assert(crossDomainId);
+
+                analytics.assert(res.crossDomainId === crossDomainId);
+                analytics.assert(res.fromDomain === 'localhost');
+
+                assert.equal(segment.getCachedCrossDomainId(), crossDomainId);
+              });
+
+              it('should bail if all servers error', function() {
+                var err = null;
+                var res = null;
+                segment.retrieveCrossDomainId(function(error, response) {
+                  err = error;
+                  res = response;
+                });
+
+                server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
+                  500,
+                  { 'Content-Type': 'application/json' },
+                  ''
+                ]);
+                server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
+                  500,
+                  { 'Content-Type': 'application/json' },
+                  ''
+                ]);
+                server.respond();
+
+                var identify = segment.onidentify.args[0];
+                analytics.assert(!identify);
+                analytics.assert(!res);
+                analytics.assert(err === 'Internal Server Error');
+
+                assert.equal(segment.getCachedCrossDomainId(), null);
+              });
+
+              it('should bail if some servers fail and others have no xid', function() {
+                var err = null;
+                var res = null;
+                segment.retrieveCrossDomainId(function(error, response) {
+                  err = error;
+                  res = response;
+                });
+
+                server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
+                  400,
+                  { 'Content-Type': 'application/json' },
+                  ''
+                ]);
+                server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
+                  200,
+                  { 'Content-Type': 'application/json' },
+                  '{ "id": null }'
+                ]);
+                server.respond();
+
+                var identify = segment.onidentify.args[0];
+                analytics.assert(!identify);
+                analytics.assert(!res);
+                analytics.assert(err === 'Bad Request');
+
+                assert.equal(segment.getCachedCrossDomainId(), null);
+              });
+
+              it('should succeed even if one server fails', function() {
+                var err = null;
+                var res = null;
+                segment.retrieveCrossDomainId(function(error, response) {
+                  err = error;
+                  res = response;
+                });
+
+                server.respondWith('GET', 'https://xid.domain2.com/v1/id/' + segment.options.apiKey, [
+                  500,
+                  { 'Content-Type': 'application/json' },
+                  ''
+                ]);
+                server.respondWith('GET', 'https://userdata.example1.com/v1/id/' + segment.options.apiKey, [
+                  200,
+                  { 'Content-Type': 'application/json' },
+                  '{ "id": "xidxid" }'
+                ]);
+                server.respond();
+
+                var identify = segment.onidentify.args[0];
+                analytics.assert(identify[0].traits().crossDomainId === 'xidxid');
+
+                analytics.assert(res.crossDomainId === 'xidxid');
+                analytics.assert(res.fromDomain === 'userdata.example1.com');
+                analytics.assert(!err);
+
+                assert.equal(segment.getCachedCrossDomainId(), 'xidxid');
+              });
+            });
+          }
 
           describe('isCrossDomainAnalyticsEnabled', function() {
             it('should return false when crossDomainIdServers is undefined', function() {
@@ -1113,6 +1207,8 @@ describe('Segment.io', function() {
               segment.cookie('seg_xid', 'test_xid');
               segment.cookie('seg_xid_ts', 'test_xid_ts');
               segment.cookie('seg_xid_fd', 'test_xid_fd');
+              store('seg_xid', 'test_xid');
+
               analytics.identify({
                 crossDomainId: 'test_xid'
               });
@@ -1122,6 +1218,7 @@ describe('Segment.io', function() {
               assert.equal(segment.cookie('seg_xid'), null);
               assert.equal(segment.cookie('seg_xid_ts'), null);
               assert.equal(segment.cookie('seg_xid_fd'), null);
+              assert.equal(store('seg_xid'), null);
               assert.equal(analytics.user().traits().crossDomainId, null);
             });
 
@@ -1176,9 +1273,6 @@ describe('Segment.io', function() {
 
     beforeEach(function(done) {
       xhr = sinon.useFakeXMLHttpRequest();
-      if (window.localStorage) {
-        window.localStorage.clear();
-      }
       analytics.once('ready', done);
       segment.options.retryQueue = true;
       analytics.initialize();


### PR DESCRIPTION
Previously cross domain analytics metadata was stored as client side cookies. This change allows us to set the cookies from a server as httpOnly cookies. We also store the identifier in localStorage To allow the current domain to read it from javascript. This behaviour is behind a flag `saveCrossDomainIdInLocalStorage` that is off by default.

This also removes some of the extraneous metadata that we don't use (such as the domain of the cookie and timestamp of the cookie), and also removes code to migrate legacy cookies.