### PR TITLE
fix(test): use singleRun:true for karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,10 @@ module.exports = function(config) {
     files: [
       'test/**/*.test.js'
     ],
+    
     browsers: ['PhantomJS'],
+
+    singleRun: true,
 
     middleware: ['server'],
 


### PR DESCRIPTION
This allows us to run tests from the release script, so that they don't infinitely wait when `yarn
np` invokes `yarn test`.