### PR TITLE
ci(publish): run publish step on tags with `v` prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(-.+)?/
+              only: /v[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
               ignore: /.*/


### PR DESCRIPTION
Previously the CI would only run on tags like `1.0.1`, but since `np` uses the `v` prefix, we want to run the publish step on tags like `v1.0.1`.