### PR TITLE
fixes flaky test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1387,6 +1387,15 @@ describe('Segment.io', function() {
 
     var headers = { 'Content-Type': 'application/json' };
 
+    it('should timeout', function(done) {
+      if (send.type !== 'xhr') return done();
+
+      Segment.sendJsonWithTimeout(url, [1, 2, 3], headers, 1, function(err) {
+        assert(err.type === 'timeout');
+        done();
+      });
+    });
+
     it('should work', function(done) {
       if (send.type !== 'xhr') return done();
 
@@ -1394,15 +1403,6 @@ describe('Segment.io', function() {
         if (err) return done(new Error(err.message));
         var res = JSON.parse(req.responseText);
         assert(res === true);
-        done();
-      });
-    });
-
-    it('should timeout', function(done) {
-      if (send.type !== 'xhr') return done();
-
-      Segment.sendJsonWithTimeout(url, [1, 2, 3], headers, 1, function(err) {
-        assert(err.type === 'timeout');
         done();
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1391,7 +1391,12 @@ describe('Segment.io', function() {
       if (send.type !== 'xhr') return done();
 
       Segment.sendJsonWithTimeout(url, [1, 2, 3], headers, 1, function(err) {
-        assert(err.type === 'timeout');
+        if (err !== null) {
+          assert(err.type === 'timeout');
+        } else {
+          // Fail instead of hang if test didn't timeout properly
+          assert(false);
+        }
         done();
       });
     });


### PR DESCRIPTION
https://segment.atlassian.net/browse/LIB-1174

Seems like the flaky test was caused by some race condition where if the other test ('should work') was called first then it would sometimes not timeout fast enough and null would be returned as the error (and test would hang when trying to access err.type)